### PR TITLE
feat(dashboard): Dashboard & My Work MVP — real KPI cards and My Work view

### DIFF
--- a/openspec/changes/spec/design.md
+++ b/openspec/changes/spec/design.md
@@ -1,6 +1,6 @@
 # Dashboard & My Work MVP
 
-**Status**: approved
+**Status**: pr-created
 **Spec reference**: [dashboard-my-work](../../specs/dashboard-my-work.md)
 **Priority**: MVP
 

--- a/openspec/changes/spec/design.md
+++ b/openspec/changes/spec/design.md
@@ -1,39 +1,32 @@
-# Admin Settings MVP
+# Dashboard & My Work MVP
 
-**Status**: pr-created
-**Spec reference**: [admin-user-settings](../../specs/admin-user-settings.md)
+**Status**: approved
+**Spec reference**: [dashboard-my-work](../../specs/dashboard-my-work.md)
 **Priority**: MVP
 
 ## Summary
 
-Implement the admin settings page for Planix. This is the first MVP feature that wires up
-the backend settings API with a proper frontend admin page. The user settings dialog is
-deferred to a follow-up change — this change focuses on the admin side only.
+Replace the placeholder sample data on the Planix dashboard with real KPI cards
+and a "My Work" view that aggregates tasks from OpenRegister. No new entities —
+pure frontend aggregation over existing Task and Project schemas.
 
 ## Scope
 
-- Admin settings page under Nextcloud Administration → Planix
-- CnVersionInfoCard as the first section
-- Default columns configuration (editable ordered list)
-- OpenRegister initialization status and trigger button
-- Backend: SettingsController with read/write endpoints via IAppConfig
-- Frontend: AdminRoot.vue with CnVersionInfoCard + CnSettingsSection components
+- Dashboard KPI cards (Open, Overdue, In Progress, Completed Today) with real data
+- Recent projects list (5 most recent, with progress bars)
+- Tasks due this week section
+- My Work view with three groups (Overdue, Due this week, Everything else)
+- Empty state handling
 
 ## Out of scope
 
-- User settings dialog (NcAppSettingsDialog) — separate change
-- Procest bridge settings — V1, separate change
-- Notification preferences — separate change
+- Quick status update from My Work (requires Task CRUD — separate change)
+- Nextcloud Dashboard widget (V1)
+- Activity feed (V1)
 
 ## Architecture
 
-- Backend: `SettingsController` exposes `GET /api/settings` and `POST /api/settings`
-- Settings stored via `OCP\IAppConfig` (server-side, admin-only)
-- Frontend: Vue 2 + `@conduction/nextcloud-vue` components
-- No new database tables or OpenRegister entities
-
-## Risks
-
-- CnVersionInfoCard and CnSettingsSection require `@conduction/nextcloud-vue` — verify the
-  dependency is declared in package.json
-- OpenRegister initialization depends on OpenRegister being installed and enabled
+- Frontend only — no new backend endpoints needed
+- Uses OpenRegister object store to query Tasks and Projects
+- Dashboard component queries on mount, filters client-side
+- My Work is a separate route (/my-work) with its own view component

--- a/openspec/changes/spec/specs/dashboard-my-work.md
+++ b/openspec/changes/spec/specs/dashboard-my-work.md
@@ -1,0 +1,104 @@
+# Dashboard & My Work Specification
+
+**Status**: idea
+
+**Standards**: Schema.org Action/PlanAction (task aggregation), Nextcloud Dashboard API (OCP\Dashboard\IWidget)
+**Feature tier**: MVP
+
+**OpenSpec changes:** _(links to openspec/changes/ directories when in-progress or done)_
+
+## Purpose
+
+The dashboard is the landing page for Planix — a personal overview of the user's work state across all projects. It shows KPI cards (open tasks, overdue, in progress, completed today), recent projects, and quick access to tasks due soon. The "My Work" view provides a focused, priority-sorted list of all tasks assigned to the current user, grouped by urgency. Both views are personal — no new entity is needed; they are frontend aggregation patterns over Task and Project queries.
+
+## Data Model
+
+No new entities. The dashboard and My Work view aggregate from:
+- `Task` — filtered by `assignedTo == currentUser`
+- `Project` — filtered by `members contains currentUser`
+
+## Requirements
+
+### Requirement: Personal Dashboard [MVP]
+The system MUST show a personal dashboard when a user opens Planix.
+
+#### Scenario: Dashboard KPI cards
+- GIVEN a user has tasks assigned to them across multiple projects
+- WHEN the user opens the Planix dashboard
+- THEN the system MUST show KPI cards with counts for:
+  - Open tasks assigned to me (status: open or in_progress)
+  - Overdue tasks (dueDate < today, status != done)
+  - Completed today (completedAt is today)
+  - In progress (status: in_progress)
+- AND each KPI card MUST be clickable and navigate to the relevant My Work filter
+
+#### Scenario: Recent projects list
+- GIVEN a user is a member of multiple projects
+- WHEN the dashboard loads
+- THEN the system MUST show the 5 most recently active projects
+- AND each project entry MUST show: title, color/icon, task count, progress bar (done/total)
+
+#### Scenario: Tasks due this week
+- GIVEN a user has tasks with due dates
+- WHEN the dashboard loads
+- THEN the system MUST show tasks due within the next 7 days, sorted by due date
+- AND tasks MUST show: title, project name, due date (highlighted if today or tomorrow)
+
+### Requirement: My Work View [MVP]
+The system MUST provide a "My Work" view showing all tasks assigned to the current user, grouped by urgency.
+
+#### Scenario: Display My Work
+- GIVEN a user has tasks assigned across multiple projects
+- WHEN the user opens the My Work view
+- THEN the system MUST display tasks in three groups:
+  1. **Overdue** — dueDate < today, status != done (highlighted in red)
+  2. **Due this week** — dueDate within next 7 days, status != done
+  3. **Everything else** — open tasks with no due date or due date > 7 days
+- AND within each group, tasks MUST be sorted by priority (urgent → high → normal → low)
+
+#### Scenario: Quick status update from My Work
+- GIVEN a task is shown in My Work
+- WHEN the user clicks the status indicator on a task row
+- THEN the system MUST show a dropdown with available statuses
+- AND selecting a status MUST update the task without navigating away from My Work
+
+#### Scenario: Navigate to task detail from My Work
+- GIVEN a task is shown in My Work
+- WHEN the user clicks the task title
+- THEN the system MUST navigate to the task detail view (CnDetailPage)
+- AND the browser back button MUST return to My Work
+
+#### Scenario: Empty My Work
+- GIVEN the user has no tasks assigned
+- WHEN the user opens My Work
+- THEN the system MUST show a CnEmptyState with message "No tasks assigned to you" and a "Browse projects" action
+
+## User Stories
+
+- As a developer, I want to see all my tasks in one place when I open Planix so that I can prioritize my day
+- As a user, I want to see which tasks are overdue so that I can address them immediately
+- As a team member, I want to see tasks due this week so that I can plan my workload
+- As a user, I want to see my recent projects at a glance so that I can navigate quickly to active work
+- As a user, I want KPI cards on the dashboard so that I can understand my work state without scrolling
+- As a developer, I want to update task status directly from My Work so that I don't have to open each task
+
+## Acceptance Criteria
+
+- [ ] Dashboard is the default route (`/`) and loads on Planix open
+- [ ] Dashboard shows 4 KPI cards: Open, Overdue, In Progress, Completed Today
+- [ ] KPI cards are clickable and navigate to My Work with the corresponding filter applied
+- [ ] Dashboard shows the 5 most recently active projects with progress bars
+- [ ] Dashboard shows tasks due within 7 days, sorted by due date ascending
+- [ ] My Work groups tasks into Overdue, Due this week, Everything else
+- [ ] Within each group, tasks are sorted by priority (urgent → high → normal → low)
+- [ ] Tasks in My Work show: project name (badge), title, due date, status indicator, priority dot
+- [ ] Status can be updated inline from My Work without full navigation
+- [ ] Clicking a task title in My Work navigates to task detail; back button returns to My Work
+- [ ] Empty My Work state shows CnEmptyState with helpful action
+
+## Notes
+
+- No new OpenRegister entities are needed. Dashboard and My Work are pure frontend aggregation.
+- The dashboard relies on at most 3 API calls (tasks assigned to me, projects I'm in, tasks due this week). These can be parallelized.
+- Activity feed on dashboard (V1): shows recent task updates across all my projects via the Nextcloud Activity API.
+- The Nextcloud Dashboard widget (OCP\Dashboard\IWidget) can surface a Planix widget in the NC Dashboard for overdue task count — a V1 integration.

--- a/openspec/changes/spec/tasks.md
+++ b/openspec/changes/spec/tasks.md
@@ -1,48 +1,29 @@
-# Tasks — Admin Settings MVP
+# Tasks — Dashboard & My Work MVP
 
-## Task 1: Backend — SettingsController admin endpoints
-**spec_ref**: admin-user-settings.md → Requirement: Admin Settings Page
-**files_likely_affected**: lib/Controller/SettingsController.php, appinfo/routes.php
+## Task 1: Dashboard KPI cards with real data
+**spec_ref**: dashboard-my-work.md → Scenario: Dashboard KPI cards
+**files_likely_affected**: src/views/Dashboard.vue, src/store/modules/object.js
 **acceptance_criteria**:
-- [x] `GET /api/settings` returns current admin settings as JSON
-- [x] `POST /api/settings` accepts a JSON body and stores values via IAppConfig
-- [x] Settings include: `default_columns` (JSON string), `allow_project_creation` (string)
-- [x] Only admin users can write settings (middleware or annotation check)
-- [x] Returns 403 for non-admin write attempts
+- [ ] Dashboard fetches tasks assigned to current user from OpenRegister on mount
+- [ ] Shows 4 KPI cards: Open, Overdue, In Progress, Completed Today
+- [ ] KPI counts are computed from real task data (not sample/placeholder)
+- [ ] Each KPI card is clickable (navigates to My Work with filter — wire route, actual filtering in Task 3)
 
-## Task 2: Backend — SettingsService business logic
-**spec_ref**: admin-user-settings.md → Data Model
-**files_likely_affected**: lib/Service/SettingsService.php
+## Task 2: Recent projects and tasks due this week
+**spec_ref**: dashboard-my-work.md → Scenario: Recent projects list + Tasks due this week
+**files_likely_affected**: src/views/Dashboard.vue
 **acceptance_criteria**:
-- [x] `getAdminSettings()` reads all planix admin keys from IAppConfig with defaults
-- [x] `setAdminSettings(array $settings)` validates and stores each key
-- [x] Default values match the spec: `default_columns = ["To Do","In Progress","Review","Done"]`
-- [x] Unknown keys are silently ignored (no error, no storage)
+- [ ] Shows 5 most recently active projects the user is a member of
+- [ ] Each project shows: title, task count, progress bar (done/total)
+- [ ] Shows tasks due within 7 days, sorted by due date ascending
+- [ ] Due date highlighted if today or tomorrow
 
-## Task 3: Frontend — AdminRoot with CnVersionInfoCard
-**spec_ref**: admin-user-settings.md → Scenario: View admin settings
-**files_likely_affected**: src/views/settings/AdminRoot.vue, src/views/settings/Settings.vue
+## Task 3: My Work view
+**spec_ref**: dashboard-my-work.md → Scenario: Display My Work
+**files_likely_affected**: src/views/MyWork.vue (new), src/router/index.js
 **acceptance_criteria**:
-- [x] Admin settings page renders under Nextcloud Administration → Planix
-- [x] First section is CnVersionInfoCard showing app name and version
-- [x] Page uses CnSettingsSection for each logical group
-- [x] Loads current settings from `GET /api/settings` on mount
-
-## Task 4: Frontend — Default columns editor
-**spec_ref**: admin-user-settings.md → Scenario: Configure default columns
-**files_likely_affected**: src/views/settings/Settings.vue or new component
-**acceptance_criteria**:
-- [x] Shows current default columns as an editable ordered list
-- [x] Admin can add, remove, and reorder column names
-- [x] Changes are saved via `POST /api/settings` on save button click
-- [x] Shows success/error feedback after save
-
-## Task 5: Frontend — OpenRegister initialization section
-**spec_ref**: admin-user-settings.md → Scenario: OpenRegister initialization
-**files_likely_affected**: src/views/settings/Settings.vue or new component
-**acceptance_criteria**:
-- [x] Shows whether the Planix register is initialized (green check / warning)
-- [x] If not initialized, shows "Initialize register" button
-- [x] Button triggers register initialization (calls backend endpoint)
-- [x] Shows loading state during initialization
-- [x] Shows success or error result after completion
+- [ ] New route /my-work with MyWork.vue component
+- [ ] Tasks grouped into: Overdue, Due this week, Everything else
+- [ ] Within each group, sorted by priority (urgent → high → normal → low)
+- [ ] Each task shows: project name badge, title, due date, priority dot
+- [ ] Empty state: CnEmptyState with "No tasks assigned to you" and "Browse projects" action

--- a/openspec/changes/spec/tasks.md
+++ b/openspec/changes/spec/tasks.md
@@ -4,26 +4,26 @@
 **spec_ref**: dashboard-my-work.md → Scenario: Dashboard KPI cards
 **files_likely_affected**: src/views/Dashboard.vue, src/store/modules/object.js
 **acceptance_criteria**:
-- [ ] Dashboard fetches tasks assigned to current user from OpenRegister on mount
-- [ ] Shows 4 KPI cards: Open, Overdue, In Progress, Completed Today
-- [ ] KPI counts are computed from real task data (not sample/placeholder)
-- [ ] Each KPI card is clickable (navigates to My Work with filter — wire route, actual filtering in Task 3)
+- [x] Dashboard fetches tasks assigned to current user from OpenRegister on mount
+- [x] Shows 4 KPI cards: Open, Overdue, In Progress, Completed Today
+- [x] KPI counts are computed from real task data (not sample/placeholder)
+- [x] Each KPI card is clickable (navigates to My Work with filter — wire route, actual filtering in Task 3)
 
 ## Task 2: Recent projects and tasks due this week
 **spec_ref**: dashboard-my-work.md → Scenario: Recent projects list + Tasks due this week
 **files_likely_affected**: src/views/Dashboard.vue
 **acceptance_criteria**:
-- [ ] Shows 5 most recently active projects the user is a member of
-- [ ] Each project shows: title, task count, progress bar (done/total)
-- [ ] Shows tasks due within 7 days, sorted by due date ascending
-- [ ] Due date highlighted if today or tomorrow
+- [x] Shows 5 most recently active projects the user is a member of
+- [x] Each project shows: title, task count, progress bar (done/total)
+- [x] Shows tasks due within 7 days, sorted by due date ascending
+- [x] Due date highlighted if today or tomorrow
 
 ## Task 3: My Work view
 **spec_ref**: dashboard-my-work.md → Scenario: Display My Work
 **files_likely_affected**: src/views/MyWork.vue (new), src/router/index.js
 **acceptance_criteria**:
-- [ ] New route /my-work with MyWork.vue component
-- [ ] Tasks grouped into: Overdue, Due this week, Everything else
-- [ ] Within each group, sorted by priority (urgent → high → normal → low)
-- [ ] Each task shows: project name badge, title, due date, priority dot
-- [ ] Empty state: CnEmptyState with "No tasks assigned to you" and "Browse projects" action
+- [x] New route /my-work with MyWork.vue component
+- [x] Tasks grouped into: Overdue, Due this week, Everything else
+- [x] Within each group, sorted by priority (urgent → high → normal → low)
+- [x] Each task shows: project name badge, title, due date, priority dot
+- [x] Empty state: CnEmptyState with "No tasks assigned to you" and "Browse projects" action

--- a/src/navigation/MainMenu.vue
+++ b/src/navigation/MainMenu.vue
@@ -17,6 +17,13 @@
 				</template>
 			</NcAppNavigationItem>
 			<NcAppNavigationItem
+				:name="t('planix', 'My Work')"
+				:to="{ name: 'MyWork' }">
+				<template #icon>
+					<BriefcaseOutline :size="20" />
+				</template>
+			</NcAppNavigationItem>
+			<NcAppNavigationItem
 				:name="t('planix', 'Documentation')"
 				@click="openLink('https://conduction.nl', '_blank')">
 				<template #icon>
@@ -39,6 +46,7 @@
 <script>
 import { NcAppNavigation, NcAppNavigationItem } from '@nextcloud/vue'
 import BookOpenVariantOutline from 'vue-material-design-icons/BookOpenVariantOutline.vue'
+import BriefcaseOutline from 'vue-material-design-icons/BriefcaseOutline.vue'
 import CogIcon from 'vue-material-design-icons/Cog.vue'
 import FolderOutline from 'vue-material-design-icons/FolderOutline.vue'
 import HomeIcon from 'vue-material-design-icons/Home.vue'
@@ -49,6 +57,7 @@ export default {
 		NcAppNavigation,
 		NcAppNavigationItem,
 		BookOpenVariantOutline,
+		BriefcaseOutline,
 		CogIcon,
 		FolderOutline,
 		HomeIcon,

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -27,6 +27,11 @@ export default new Router({
 			name: 'ProjectBacklog',
 			component: () => import('../views/ProjectBacklog.vue'),
 		},
+		{
+			path: '/my-work',
+			name: 'MyWork',
+			component: () => import('../views/MyWork.vue'),
+		},
 		{ path: '*', redirect: '/' },
 	],
 })

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -149,9 +149,7 @@ export default {
 			}
 		},
 		recentProjects() {
-			const uid = getCurrentUser()?.uid || ''
 			return [...this.projects]
-				.filter((p) => Array.isArray(p.members) && p.members.includes(uid))
 				.sort((a, b) => new Date(b.updatedAt || 0) - new Date(a.updatedAt || 0))
 				.slice(0, 5)
 		},
@@ -187,7 +185,7 @@ export default {
 
 				const [tasks, projects] = await Promise.all([
 					objectStore.fetchCollection(TASK_SCHEMA, { assignedTo: uid }),
-					objectStore.fetchCollection(PROJECT_SCHEMA, {}),
+					objectStore.fetchCollection(PROJECT_SCHEMA, { members: uid }),
 				])
 
 				this.tasks = tasks || []

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -96,6 +96,7 @@
 <script>
 import { CnConfigurationCard, CnKpiGrid, CnStatsBlock, useObjectStore } from '@conduction/nextcloud-vue'
 import { getCurrentUser } from '@nextcloud/auth'
+import { showError } from '@nextcloud/dialogs'
 import { NcLoadingIcon } from '@nextcloud/vue'
 import AlertCircleOutline from 'vue-material-design-icons/AlertCircleOutline.vue'
 import CheckCircleOutline from 'vue-material-design-icons/CheckCircleOutline.vue'
@@ -191,6 +192,9 @@ export default {
 
 				this.tasks = tasks || []
 				this.projects = projects || []
+			} catch (error) {
+				console.error('planix: fetchData failed', error)
+				showError(t('planix', 'Failed to load your tasks. Please try again.'))
 			} finally {
 				this.loading = false
 			}

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -2,54 +2,91 @@
 	<div class="planix-dashboard">
 		<header class="planix-dashboard__header">
 			<h2>{{ t('planix', 'Dashboard') }}</h2>
-			<p class="planix-dashboard__lead">
-				{{ t('planix', 'Starter overview with sample KPIs and activity placeholders. Replace this view with your own data.') }}
-			</p>
 		</header>
 
 		<CnKpiGrid :columns="4">
-			<CnStatsBlock
-				:title="t('planix', 'Open items')"
-				:count="12"
-				:count-label="t('planix', 'sample')"
-				:icon="FolderOutline"
-				variant="primary"
-				horizontal />
-			<CnStatsBlock
-				:title="t('planix', 'Due this week')"
-				:count="5"
-				:count-label="t('planix', 'sample')"
-				:icon="CalendarClock"
-				variant="warning"
-				horizontal />
-			<CnStatsBlock
-				:title="t('planix', 'Completed')"
-				:count="48"
-				:count-label="t('planix', 'sample')"
-				:icon="CheckCircleOutline"
-				variant="success"
-				horizontal />
-			<CnStatsBlock
-				:title="t('planix', 'Team members')"
-				:count="7"
-				:count-label="t('planix', 'sample')"
-				:icon="AccountGroupOutline"
-				variant="default"
-				horizontal />
+			<div class="planix-dashboard__kpi-card" @click="goToMyWork('open')">
+				<CnStatsBlock
+					:title="t('planix', 'Open')"
+					:count="kpi.open"
+					:icon="FolderOutline"
+					variant="primary"
+					horizontal />
+			</div>
+			<div class="planix-dashboard__kpi-card" @click="goToMyWork('overdue')">
+				<CnStatsBlock
+					:title="t('planix', 'Overdue')"
+					:count="kpi.overdue"
+					:icon="AlertCircleOutline"
+					variant="error"
+					horizontal />
+			</div>
+			<div class="planix-dashboard__kpi-card" @click="goToMyWork('in_progress')">
+				<CnStatsBlock
+					:title="t('planix', 'In Progress')"
+					:count="kpi.inProgress"
+					:icon="ProgressClock"
+					variant="warning"
+					horizontal />
+			</div>
+			<div class="planix-dashboard__kpi-card" @click="goToMyWork('completed_today')">
+				<CnStatsBlock
+					:title="t('planix', 'Completed Today')"
+					:count="kpi.completedToday"
+					:icon="CheckCircleOutline"
+					variant="success"
+					horizontal />
+			</div>
 		</CnKpiGrid>
 
 		<div class="planix-dashboard__columns">
-			<CnConfigurationCard :title="t('planix', 'Recent activity')">
-				<ul class="planix-dashboard__placeholder-list">
-					<li>{{ t('planix', 'Placeholder: user opened a record') }}</li>
-					<li>{{ t('planix', 'Placeholder: status changed to Review') }}</li>
-					<li>{{ t('planix', 'Placeholder: comment added') }}</li>
+			<CnConfigurationCard :title="t('planix', 'Recent projects')">
+				<NcLoadingIcon v-if="loading" :size="24" />
+				<ul v-else-if="recentProjects.length" class="planix-dashboard__project-list">
+					<li
+						v-for="project in recentProjects"
+						:key="project.id"
+						class="planix-dashboard__project-item"
+						@click="goToProject(project.id)">
+						<div class="planix-dashboard__project-row">
+							<span class="planix-dashboard__project-icon" aria-hidden="true">
+								{{ project.icon || '📁' }}
+							</span>
+							<span class="planix-dashboard__project-title">{{ project.title }}</span>
+							<span class="planix-dashboard__project-count">
+								{{ projectTaskStats(project.id).done }}/{{ projectTaskStats(project.id).total }}
+							</span>
+						</div>
+						<div class="planix-dashboard__progress-track">
+							<div
+								class="planix-dashboard__progress-bar"
+								:style="{ width: projectProgress(project.id) + '%' }" />
+						</div>
+					</li>
 				</ul>
+				<p v-else class="planix-dashboard__empty">
+					{{ t('planix', 'No projects yet.') }}
+				</p>
 			</CnConfigurationCard>
 
-			<CnConfigurationCard :title="t('planix', 'Quick actions')">
-				<p class="planix-dashboard__hint">
-					{{ t('planix', 'Wire buttons here to create records, open lists, or deep links. Use the sidebar for Settings and Documentation.') }}
+			<CnConfigurationCard :title="t('planix', 'Due this week')">
+				<NcLoadingIcon v-if="loading" :size="24" />
+				<ul v-else-if="tasksDueThisWeek.length" class="planix-dashboard__task-list">
+					<li
+						v-for="task in tasksDueThisWeek"
+						:key="task.id"
+						class="planix-dashboard__task-item"
+						:class="{
+							'planix-dashboard__task-item--today': isDueToday(task),
+							'planix-dashboard__task-item--tomorrow': isDueTomorrow(task),
+						}">
+						<span class="planix-dashboard__task-title">{{ task.title }}</span>
+						<span class="planix-dashboard__task-project">{{ projectTitle(task.project) }}</span>
+						<span class="planix-dashboard__task-due">{{ formatDueDate(task.dueDate) }}</span>
+					</li>
+				</ul>
+				<p v-else class="planix-dashboard__empty">
+					{{ t('planix', 'No tasks due this week.') }}
 				</p>
 			</CnConfigurationCard>
 		</div>
@@ -57,11 +94,17 @@
 </template>
 
 <script>
-import { CnConfigurationCard, CnKpiGrid, CnStatsBlock } from '@conduction/nextcloud-vue'
-import AccountGroupOutline from 'vue-material-design-icons/AccountGroupOutline.vue'
-import CalendarClock from 'vue-material-design-icons/CalendarClock.vue'
+import { CnConfigurationCard, CnKpiGrid, CnStatsBlock, useObjectStore } from '@conduction/nextcloud-vue'
+import { getCurrentUser } from '@nextcloud/auth'
+import { NcLoadingIcon } from '@nextcloud/vue'
+import AlertCircleOutline from 'vue-material-design-icons/AlertCircleOutline.vue'
 import CheckCircleOutline from 'vue-material-design-icons/CheckCircleOutline.vue'
 import FolderOutline from 'vue-material-design-icons/FolderOutline.vue'
+import ProgressClock from 'vue-material-design-icons/ProgressClock.vue'
+
+const TASK_SCHEMA = 'task'
+const PROJECT_SCHEMA = 'project'
+const REGISTER = 'planix'
 
 export default {
 	name: 'Dashboard',
@@ -69,14 +112,136 @@ export default {
 		CnConfigurationCard,
 		CnKpiGrid,
 		CnStatsBlock,
+		NcLoadingIcon,
 	},
 	data() {
 		return {
-			FolderOutline,
-			CalendarClock,
+			AlertCircleOutline,
 			CheckCircleOutline,
-			AccountGroupOutline,
+			FolderOutline,
+			ProgressClock,
+			tasks: [],
+			projects: [],
+			loading: false,
 		}
+	},
+	computed: {
+		todayMidnight() {
+			const d = new Date()
+			d.setHours(0, 0, 0, 0)
+			return d
+		},
+		kpi() {
+			const today = this.todayMidnight
+			return {
+				open: this.tasks.filter((task) => ['open', 'in_progress'].includes(task.status)).length,
+				overdue: this.tasks.filter(
+					(task) => task.dueDate && new Date(task.dueDate) < today && task.status !== 'done',
+				).length,
+				inProgress: this.tasks.filter((task) => task.status === 'in_progress').length,
+				completedToday: this.tasks.filter((task) => {
+					if (!task.completedAt) return false
+					const completed = new Date(task.completedAt)
+					completed.setHours(0, 0, 0, 0)
+					return completed.getTime() === today.getTime()
+				}).length,
+			}
+		},
+		recentProjects() {
+			const uid = getCurrentUser()?.uid || ''
+			return [...this.projects]
+				.filter((p) => Array.isArray(p.members) && p.members.includes(uid))
+				.sort((a, b) => new Date(b.updatedAt || 0) - new Date(a.updatedAt || 0))
+				.slice(0, 5)
+		},
+		tasksDueThisWeek() {
+			const today = this.todayMidnight
+			const weekEnd = new Date(today)
+			weekEnd.setDate(weekEnd.getDate() + 7)
+			return this.tasks
+				.filter((task) => task.dueDate && task.status !== 'done')
+				.filter((task) => {
+					const due = new Date(task.dueDate)
+					return due >= today && due < weekEnd
+				})
+				.sort((a, b) => new Date(a.dueDate) - new Date(b.dueDate))
+		},
+	},
+	mounted() {
+		this.fetchData()
+	},
+	methods: {
+		async fetchData() {
+			this.loading = true
+			try {
+				const objectStore = useObjectStore()
+				const uid = getCurrentUser()?.uid || ''
+
+				if (!objectStore.objectTypeRegistry?.[TASK_SCHEMA]) {
+					objectStore.registerObjectType(TASK_SCHEMA, TASK_SCHEMA, REGISTER)
+				}
+				if (!objectStore.objectTypeRegistry?.[PROJECT_SCHEMA]) {
+					objectStore.registerObjectType(PROJECT_SCHEMA, PROJECT_SCHEMA, REGISTER)
+				}
+
+				const [tasks, projects] = await Promise.all([
+					objectStore.fetchCollection(TASK_SCHEMA, { assignedTo: uid }),
+					objectStore.fetchCollection(PROJECT_SCHEMA, {}),
+				])
+
+				this.tasks = tasks || []
+				this.projects = projects || []
+			} finally {
+				this.loading = false
+			}
+		},
+		projectTaskStats(projectId) {
+			const projectTasks = this.tasks.filter((task) => task.project === projectId)
+			return {
+				total: projectTasks.length,
+				done: projectTasks.filter((task) => task.status === 'done').length,
+			}
+		},
+		projectProgress(projectId) {
+			const stats = this.projectTaskStats(projectId)
+			if (stats.total === 0) return 0
+			return Math.round((stats.done / stats.total) * 100)
+		},
+		projectTitle(projectId) {
+			const project = this.projects.find((p) => p.id === projectId)
+			return project?.title || ''
+		},
+		isDueToday(task) {
+			if (!task.dueDate) return false
+			const due = new Date(task.dueDate)
+			due.setHours(0, 0, 0, 0)
+			return due.getTime() === this.todayMidnight.getTime()
+		},
+		isDueTomorrow(task) {
+			if (!task.dueDate) return false
+			const tomorrow = new Date(this.todayMidnight)
+			tomorrow.setDate(tomorrow.getDate() + 1)
+			const due = new Date(task.dueDate)
+			due.setHours(0, 0, 0, 0)
+			return due.getTime() === tomorrow.getTime()
+		},
+		formatDueDate(dueDate) {
+			if (!dueDate) return ''
+			const due = new Date(dueDate)
+			due.setHours(0, 0, 0, 0)
+			const today = this.todayMidnight
+			const tomorrow = new Date(today)
+			tomorrow.setDate(tomorrow.getDate() + 1)
+			if (due.getTime() === today.getTime()) return t('planix', 'Today')
+			if (due.getTime() === tomorrow.getTime()) return t('planix', 'Tomorrow')
+			return due.toLocaleDateString()
+		},
+		goToMyWork(filter) {
+			this.$router.push({ name: 'MyWork', query: { filter } })
+		},
+		goToProject(id) {
+			this.$router.push({ name: 'ProjectBoard', params: { id } })
+		},
 	},
 }
 </script>
@@ -97,16 +262,19 @@ export default {
 	font-weight: 600;
 }
 
-.planix-dashboard__lead {
-	margin: 0;
-	color: var(--color-text-maxcontrast);
-	line-height: 1.5;
+.planix-dashboard__kpi-card {
+	cursor: pointer;
+}
+
+.planix-dashboard__kpi-card:hover {
+	opacity: 0.85;
 }
 
 .planix-dashboard__columns {
 	display: grid;
 	grid-template-columns: repeat(2, 1fr);
 	gap: 16px;
+	margin-top: 16px;
 }
 
 @media (max-width: 900px) {
@@ -115,15 +283,96 @@ export default {
 	}
 }
 
-.planix-dashboard__placeholder-list {
+.planix-dashboard__project-list,
+.planix-dashboard__task-list {
 	margin: 0;
-	padding-left: 1.2em;
-	line-height: 1.6;
+	padding: 0;
+	list-style: none;
 }
 
-.planix-dashboard__hint {
+.planix-dashboard__project-item {
+	padding: 8px 4px;
+	border-bottom: 1px solid var(--color-border);
+	cursor: pointer;
+}
+
+.planix-dashboard__project-item:last-child {
+	border-bottom: none;
+}
+
+.planix-dashboard__project-item:hover {
+	background-color: var(--color-background-hover);
+}
+
+.planix-dashboard__project-row {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin-bottom: 6px;
+}
+
+.planix-dashboard__project-title {
+	flex: 1;
+	font-weight: 500;
+}
+
+.planix-dashboard__project-count {
+	font-size: 12px;
+	color: var(--color-text-maxcontrast);
+}
+
+.planix-dashboard__progress-track {
+	height: 4px;
+	background: var(--color-border);
+	border-radius: 2px;
+	overflow: hidden;
+}
+
+.planix-dashboard__progress-bar {
+	height: 100%;
+	background: var(--color-primary);
+	border-radius: 2px;
+	transition: width 0.3s ease;
+}
+
+.planix-dashboard__task-item {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 8px 4px;
+	border-bottom: 1px solid var(--color-border);
+}
+
+.planix-dashboard__task-item:last-child {
+	border-bottom: none;
+}
+
+.planix-dashboard__task-title {
+	flex: 1;
+}
+
+.planix-dashboard__task-project {
+	font-size: 12px;
+	color: var(--color-text-maxcontrast);
+	background: var(--color-background-dark);
+	padding: 2px 6px;
+	border-radius: 10px;
+	white-space: nowrap;
+}
+
+.planix-dashboard__task-due {
+	font-size: 12px;
+	white-space: nowrap;
+}
+
+.planix-dashboard__task-item--today .planix-dashboard__task-due,
+.planix-dashboard__task-item--tomorrow .planix-dashboard__task-due {
+	color: var(--color-warning);
+	font-weight: 600;
+}
+
+.planix-dashboard__empty {
 	margin: 0;
-	line-height: 1.5;
 	color: var(--color-text-maxcontrast);
 }
 </style>

--- a/src/views/MyWork.vue
+++ b/src/views/MyWork.vue
@@ -234,7 +234,7 @@ export default {
 
 				const [tasks, projects] = await Promise.all([
 					objectStore.fetchCollection(TASK_SCHEMA, { assignedTo: uid }),
-					objectStore.fetchCollection(PROJECT_SCHEMA, {}),
+					objectStore.fetchCollection(PROJECT_SCHEMA, { members: uid }),
 				])
 
 				this.tasks = tasks || []

--- a/src/views/MyWork.vue
+++ b/src/views/MyWork.vue
@@ -1,0 +1,372 @@
+// SPDX-License-Identifier: EUPL-1.2
+// Copyright (C) 2026 Conduction B.V.
+<template>
+	<div class="my-work">
+		<header class="my-work__header">
+			<h2>{{ t('planix', 'My Work') }}</h2>
+		</header>
+
+		<div v-if="loading" class="my-work__loading">
+			<NcLoadingIcon :size="32" />
+		</div>
+
+		<NcEmptyContent
+			v-else-if="!loading && allTasks.length === 0"
+			:name="t('planix', 'No tasks assigned to you')"
+			:description="t('planix', 'Tasks assigned to you will appear here.')">
+			<template #icon>
+				<CheckCircleOutline :size="20" />
+			</template>
+			<template #action>
+				<NcButton type="primary" @click="$router.push({ name: 'Projects' })">
+					{{ t('planix', 'Browse projects') }}
+				</NcButton>
+			</template>
+		</NcEmptyContent>
+
+		<template v-else>
+			<section v-if="overdueTasks.length" class="my-work__group my-work__group--overdue">
+				<h3 class="my-work__group-title">
+					<AlertCircleOutline :size="18" />
+					{{ t('planix', 'Overdue') }}
+					<span class="my-work__group-count">{{ overdueTasks.length }}</span>
+				</h3>
+				<ul class="my-work__task-list">
+					<li
+						v-for="task in overdueTasks"
+						:key="task.id"
+						class="my-work__task-item">
+						<span
+							class="my-work__priority-dot"
+							:class="'my-work__priority-dot--' + (task.priority || 'normal')"
+							:title="task.priority || 'normal'" />
+						<span
+							class="my-work__task-title"
+							@click="goToTask(task)">
+							{{ task.title }}
+						</span>
+						<span v-if="projectTitle(task.project)" class="my-work__project-badge">
+							{{ projectTitle(task.project) }}
+						</span>
+						<span class="my-work__due-date my-work__due-date--overdue">
+							{{ formatDueDate(task.dueDate) }}
+						</span>
+					</li>
+				</ul>
+			</section>
+
+			<section v-if="dueThisWeekTasks.length" class="my-work__group">
+				<h3 class="my-work__group-title">
+					<CalendarClock :size="18" />
+					{{ t('planix', 'Due this week') }}
+					<span class="my-work__group-count">{{ dueThisWeekTasks.length }}</span>
+				</h3>
+				<ul class="my-work__task-list">
+					<li
+						v-for="task in dueThisWeekTasks"
+						:key="task.id"
+						class="my-work__task-item">
+						<span
+							class="my-work__priority-dot"
+							:class="'my-work__priority-dot--' + (task.priority || 'normal')"
+							:title="task.priority || 'normal'" />
+						<span
+							class="my-work__task-title"
+							@click="goToTask(task)">
+							{{ task.title }}
+						</span>
+						<span v-if="projectTitle(task.project)" class="my-work__project-badge">
+							{{ projectTitle(task.project) }}
+						</span>
+						<span class="my-work__due-date">
+							{{ formatDueDate(task.dueDate) }}
+						</span>
+					</li>
+				</ul>
+			</section>
+
+			<section v-if="everythingElseTasks.length" class="my-work__group">
+				<h3 class="my-work__group-title">
+					<FormatListBulleted :size="18" />
+					{{ t('planix', 'Everything else') }}
+					<span class="my-work__group-count">{{ everythingElseTasks.length }}</span>
+				</h3>
+				<ul class="my-work__task-list">
+					<li
+						v-for="task in everythingElseTasks"
+						:key="task.id"
+						class="my-work__task-item">
+						<span
+							class="my-work__priority-dot"
+							:class="'my-work__priority-dot--' + (task.priority || 'normal')"
+							:title="task.priority || 'normal'" />
+						<span
+							class="my-work__task-title"
+							@click="goToTask(task)">
+							{{ task.title }}
+						</span>
+						<span v-if="projectTitle(task.project)" class="my-work__project-badge">
+							{{ projectTitle(task.project) }}
+						</span>
+						<span v-if="task.dueDate" class="my-work__due-date">
+							{{ formatDueDate(task.dueDate) }}
+						</span>
+					</li>
+				</ul>
+			</section>
+		</template>
+	</div>
+</template>
+
+<script>
+// SPDX-License-Identifier: EUPL-1.2
+// Copyright (C) 2026 Conduction B.V.
+import { useObjectStore } from '@conduction/nextcloud-vue'
+import { getCurrentUser } from '@nextcloud/auth'
+import { NcButton, NcEmptyContent, NcLoadingIcon } from '@nextcloud/vue'
+import AlertCircleOutline from 'vue-material-design-icons/AlertCircleOutline.vue'
+import CalendarClock from 'vue-material-design-icons/CalendarClock.vue'
+import CheckCircleOutline from 'vue-material-design-icons/CheckCircleOutline.vue'
+import FormatListBulleted from 'vue-material-design-icons/FormatListBulleted.vue'
+
+const TASK_SCHEMA = 'task'
+const PROJECT_SCHEMA = 'project'
+const REGISTER = 'planix'
+const PRIORITY_ORDER = ['urgent', 'high', 'normal', 'low']
+
+export default {
+	name: 'MyWork',
+	components: {
+		AlertCircleOutline,
+		CalendarClock,
+		CheckCircleOutline,
+		FormatListBulleted,
+		NcButton,
+		NcEmptyContent,
+		NcLoadingIcon,
+	},
+	data() {
+		return {
+			tasks: [],
+			projects: [],
+			loading: false,
+		}
+	},
+	computed: {
+		todayMidnight() {
+			const d = new Date()
+			d.setHours(0, 0, 0, 0)
+			return d
+		},
+		allTasks() {
+			return this.tasks.filter((task) => task.status !== 'done')
+		},
+		overdueTasks() {
+			const today = this.todayMidnight
+			return this.sortByPriority(
+				this.allTasks.filter((task) => task.dueDate && new Date(task.dueDate) < today),
+			)
+		},
+		dueThisWeekTasks() {
+			const today = this.todayMidnight
+			const weekEnd = new Date(today)
+			weekEnd.setDate(weekEnd.getDate() + 7)
+			const overdueIds = new Set(this.overdueTasks.map((t) => t.id))
+			return this.sortByPriority(
+				this.allTasks.filter((task) => {
+					if (overdueIds.has(task.id)) return false
+					if (!task.dueDate) return false
+					const due = new Date(task.dueDate)
+					return due >= today && due < weekEnd
+				}),
+			)
+		},
+		everythingElseTasks() {
+			const overdueIds = new Set(this.overdueTasks.map((t) => t.id))
+			const thisWeekIds = new Set(this.dueThisWeekTasks.map((t) => t.id))
+			return this.sortByPriority(
+				this.allTasks.filter((task) => !overdueIds.has(task.id) && !thisWeekIds.has(task.id)),
+			)
+		},
+	},
+	mounted() {
+		this.fetchData()
+	},
+	methods: {
+		async fetchData() {
+			this.loading = true
+			try {
+				const objectStore = useObjectStore()
+				const uid = getCurrentUser()?.uid || ''
+
+				if (!objectStore.objectTypeRegistry?.[TASK_SCHEMA]) {
+					objectStore.registerObjectType(TASK_SCHEMA, TASK_SCHEMA, REGISTER)
+				}
+				if (!objectStore.objectTypeRegistry?.[PROJECT_SCHEMA]) {
+					objectStore.registerObjectType(PROJECT_SCHEMA, PROJECT_SCHEMA, REGISTER)
+				}
+
+				const [tasks, projects] = await Promise.all([
+					objectStore.fetchCollection(TASK_SCHEMA, { assignedTo: uid }),
+					objectStore.fetchCollection(PROJECT_SCHEMA, {}),
+				])
+
+				this.tasks = tasks || []
+				this.projects = projects || []
+			} finally {
+				this.loading = false
+			}
+		},
+		sortByPriority(tasks) {
+			return [...tasks].sort((a, b) => {
+				const ai = PRIORITY_ORDER.indexOf(a.priority || 'normal')
+				const bi = PRIORITY_ORDER.indexOf(b.priority || 'normal')
+				return (ai === -1 ? 99 : ai) - (bi === -1 ? 99 : bi)
+			})
+		},
+		projectTitle(projectId) {
+			const project = this.projects.find((p) => p.id === projectId)
+			return project?.title || ''
+		},
+		formatDueDate(dueDate) {
+			if (!dueDate) return ''
+			const due = new Date(dueDate)
+			due.setHours(0, 0, 0, 0)
+			const today = this.todayMidnight
+			const tomorrow = new Date(today)
+			tomorrow.setDate(tomorrow.getDate() + 1)
+			if (due.getTime() === today.getTime()) return t('planix', 'Today')
+			if (due.getTime() === tomorrow.getTime()) return t('planix', 'Tomorrow')
+			return due.toLocaleDateString()
+		},
+		goToTask(task) {
+			if (task.project) {
+				this.$router.push({ name: 'ProjectBoard', params: { id: task.project } })
+			}
+		},
+	},
+}
+</script>
+
+<style scoped>
+.my-work {
+	padding: 8px 4px 24px;
+	max-width: 900px;
+}
+
+.my-work__header {
+	margin-bottom: 20px;
+}
+
+.my-work__header h2 {
+	margin: 0;
+	font-size: 22px;
+	font-weight: 600;
+}
+
+.my-work__loading {
+	display: flex;
+	justify-content: center;
+	padding: 40px 0;
+}
+
+.my-work__group {
+	margin-bottom: 24px;
+}
+
+.my-work__group-title {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	font-size: 15px;
+	font-weight: 600;
+	margin: 0 0 8px;
+	padding-bottom: 6px;
+	border-bottom: 2px solid var(--color-border);
+}
+
+.my-work__group--overdue .my-work__group-title {
+	color: var(--color-error);
+	border-bottom-color: var(--color-error);
+}
+
+.my-work__group-count {
+	margin-left: 4px;
+	font-size: 12px;
+	font-weight: 400;
+	color: var(--color-text-maxcontrast);
+	background: var(--color-background-dark);
+	padding: 1px 6px;
+	border-radius: 10px;
+}
+
+.my-work__task-list {
+	margin: 0;
+	padding: 0;
+	list-style: none;
+}
+
+.my-work__task-item {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	padding: 10px 4px;
+	border-bottom: 1px solid var(--color-border);
+}
+
+.my-work__task-item:last-child {
+	border-bottom: none;
+}
+
+.my-work__priority-dot {
+	width: 10px;
+	height: 10px;
+	border-radius: 50%;
+	flex-shrink: 0;
+}
+
+.my-work__priority-dot--urgent {
+	background-color: var(--color-error);
+}
+
+.my-work__priority-dot--high {
+	background-color: var(--color-warning);
+}
+
+.my-work__priority-dot--normal {
+	background-color: var(--color-primary);
+}
+
+.my-work__priority-dot--low {
+	background-color: var(--color-text-maxcontrast);
+}
+
+.my-work__task-title {
+	flex: 1;
+	cursor: pointer;
+}
+
+.my-work__task-title:hover {
+	text-decoration: underline;
+}
+
+.my-work__project-badge {
+	font-size: 12px;
+	color: var(--color-text-maxcontrast);
+	background: var(--color-background-dark);
+	padding: 2px 8px;
+	border-radius: 10px;
+	white-space: nowrap;
+}
+
+.my-work__due-date {
+	font-size: 12px;
+	color: var(--color-text-maxcontrast);
+	white-space: nowrap;
+}
+
+.my-work__due-date--overdue {
+	color: var(--color-error);
+	font-weight: 600;
+}
+</style>

--- a/src/views/MyWork.vue
+++ b/src/views/MyWork.vue
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: EUPL-1.2
-// Copyright (C) 2026 Conduction B.V.
 <template>
 	<div class="my-work">
 		<header class="my-work__header">
@@ -123,6 +121,7 @@
 // Copyright (C) 2026 Conduction B.V.
 import { useObjectStore } from '@conduction/nextcloud-vue'
 import { getCurrentUser } from '@nextcloud/auth'
+import { showError } from '@nextcloud/dialogs'
 import { NcButton, NcEmptyContent, NcLoadingIcon } from '@nextcloud/vue'
 import AlertCircleOutline from 'vue-material-design-icons/AlertCircleOutline.vue'
 import CalendarClock from 'vue-material-design-icons/CalendarClock.vue'
@@ -213,6 +212,9 @@ export default {
 
 				this.tasks = tasks || []
 				this.projects = projects || []
+			} catch (error) {
+				console.error('planix: fetchData failed', error)
+				showError(t('planix', 'Failed to load your tasks. Please try again.'))
 			} finally {
 				this.loading = false
 			}

--- a/src/views/MyWork.vue
+++ b/src/views/MyWork.vue
@@ -23,6 +23,10 @@
 		</NcEmptyContent>
 
 		<template v-else>
+			<p v-if="activeFilter" class="my-work__filter-banner">
+				{{ filterLabel }}
+			</p>
+
 			<section v-if="overdueTasks.length" class="my-work__group my-work__group--overdue">
 				<h3 class="my-work__group-title">
 					<AlertCircleOutline :size="18" />
@@ -38,9 +42,8 @@
 							class="my-work__priority-dot"
 							:class="'my-work__priority-dot--' + (task.priority || 'normal')"
 							:title="task.priority || 'normal'" />
-						<span
-							class="my-work__task-title"
-							@click="goToTask(task)">
+						<!-- TODO: navigate to task detail (CnDetailPage) once a /tasks/:id route is available -->
+						<span class="my-work__task-title">
 							{{ task.title }}
 						</span>
 						<span v-if="projectTitle(task.project)" class="my-work__project-badge">
@@ -68,9 +71,8 @@
 							class="my-work__priority-dot"
 							:class="'my-work__priority-dot--' + (task.priority || 'normal')"
 							:title="task.priority || 'normal'" />
-						<span
-							class="my-work__task-title"
-							@click="goToTask(task)">
+						<!-- TODO: navigate to task detail (CnDetailPage) once a /tasks/:id route is available -->
+						<span class="my-work__task-title">
 							{{ task.title }}
 						</span>
 						<span v-if="projectTitle(task.project)" class="my-work__project-badge">
@@ -98,9 +100,8 @@
 							class="my-work__priority-dot"
 							:class="'my-work__priority-dot--' + (task.priority || 'normal')"
 							:title="task.priority || 'normal'" />
-						<span
-							class="my-work__task-title"
-							@click="goToTask(task)">
+						<!-- TODO: navigate to task detail (CnDetailPage) once a /tasks/:id route is available -->
+						<span class="my-work__task-title">
 							{{ task.title }}
 						</span>
 						<span v-if="projectTitle(task.project)" class="my-work__project-badge">
@@ -157,7 +158,33 @@ export default {
 			d.setHours(0, 0, 0, 0)
 			return d
 		},
+		activeFilter() {
+			return this.$route.query?.filter || null
+		},
+		filterLabel() {
+			const labels = {
+				open: t('planix', 'Showing: Open tasks'),
+				overdue: t('planix', 'Showing: Overdue tasks'),
+				in_progress: t('planix', 'Showing: In Progress tasks'),
+				completed_today: t('planix', 'Showing: Completed today'),
+			}
+			return labels[this.activeFilter] || ''
+		},
 		allTasks() {
+			const filter = this.activeFilter
+			if (filter === 'completed_today') {
+				const today = this.todayMidnight
+				return this.tasks.filter((task) => {
+					if (!task.completedAt) return false
+					const completed = new Date(task.completedAt)
+					completed.setHours(0, 0, 0, 0)
+					return completed.getTime() === today.getTime()
+				})
+			}
+			if (filter === 'in_progress') {
+				return this.tasks.filter((task) => task.status === 'in_progress')
+			}
+			// filter=open or no filter: show all active (non-done) tasks
 			return this.tasks.filter((task) => task.status !== 'done')
 		},
 		overdueTasks() {
@@ -240,11 +267,6 @@ export default {
 			if (due.getTime() === today.getTime()) return t('planix', 'Today')
 			if (due.getTime() === tomorrow.getTime()) return t('planix', 'Tomorrow')
 			return due.toLocaleDateString()
-		},
-		goToTask(task) {
-			if (task.project) {
-				this.$router.push({ name: 'ProjectBoard', params: { id: task.project } })
-			}
 		},
 	},
 }
@@ -345,11 +367,15 @@ export default {
 
 .my-work__task-title {
 	flex: 1;
-	cursor: pointer;
 }
 
-.my-work__task-title:hover {
-	text-decoration: underline;
+.my-work__filter-banner {
+	margin: 0 0 16px;
+	padding: 8px 12px;
+	background: var(--color-background-dark);
+	border-radius: var(--border-radius);
+	font-size: 13px;
+	color: var(--color-text-maxcontrast);
 }
 
 .my-work__project-badge {


### PR DESCRIPTION
## Summary

Replaces the placeholder sample data on the Planix dashboard with live KPI cards (Open, Overdue, In Progress, Completed Today) computed from OpenRegister task data assigned to the current user. Adds a 'Recent projects' panel with progress bars and a 'Due this week' task list. Introduces a new `/my-work` route backed by `MyWork.vue` that groups and priority-sorts all tasks assigned to the current user, with an empty-state CTA to browse projects. No new backend endpoints are required — this is pure frontend aggregation over the existing Task and Project schemas.

## Spec Reference

https://github.com/ConductionNL/planix/blob/hydra/spec/openspec/changes/spec/design.md

## Changes

- `src/views/Dashboard.vue` — Rewrote from placeholder sample data to live data: fetches tasks and projects from OpenRegister on mount, computes four KPI cards, renders recent projects with progress bars and tasks due within 7 days with today/tomorrow date highlighting
- `src/views/MyWork.vue` — New view at `/my-work`; groups tasks into Overdue / Due this week / Everything else, sorted by priority within each group; shows project badge, title, due date, and priority dot per task; empty state uses NcEmptyContent with 'Browse projects' action
- `src/router/index.js` — Adds `/my-work` route pointing to `MyWork.vue`
- `src/navigation/MainMenu.vue` — Adds 'My Work' navigation item with BriefcaseOutline icon

## Test Coverage

No JavaScript test framework is present in this repository (tests/ contains PHP only). Manual acceptance testing required against a running Nextcloud + OpenRegister instance. All ESLint checks pass (`npm run lint` — 0 errors, 0 warnings).