### PR TITLE
feat: add Label CRUD endpoints

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -15,6 +15,11 @@ return [
         // Health check endpoint.
         ['name' => 'health#index', 'url' => '/api/health', 'verb' => 'GET'],
 
+        // Labels.
+        ['name' => 'label#index',   'url' => '/api/labels',      'verb' => 'GET'],
+        ['name' => 'label#create',  'url' => '/api/labels',      'verb' => 'POST'],
+        ['name' => 'label#destroy', 'url' => '/api/labels/{id}', 'verb' => 'DELETE'],
+
         // SPA catch-all — same controller as the index route; must use a distinct route name
         // (duplicate names replace the earlier route in Symfony, which breaks GET /).
         ['name' => 'dashboard#catchAll', 'url' => '/{path}', 'verb' => 'GET', 'requirements' => ['path' => '.+'], 'defaults' => ['path' => '']],

--- a/lib/Controller/LabelController.php
+++ b/lib/Controller/LabelController.php
@@ -33,7 +33,6 @@ use OCP\IRequest;
  */
 class LabelController extends Controller
 {
-
     /**
      * Constructor for the LabelController.
      *
@@ -103,9 +102,9 @@ class LabelController extends Controller
     /**
      * Delete a label by ID.
      *
-     * @NoAdminRequired
-     *
      * @param string $id The label UUID
+     *
+     * @NoAdminRequired
      *
      * @return JSONResponse
      */

--- a/lib/Controller/LabelController.php
+++ b/lib/Controller/LabelController.php
@@ -1,0 +1,133 @@
+<?php
+
+/**
+ * Planix Label Controller
+ *
+ * Controller for managing labels via REST API.
+ *
+ * @category Controller
+ * @package  OCA\Planix\Controller
+ *
+ * @author    Conduction Development Team <dev@conductio.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://conduction.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Planix\Controller;
+
+use OCA\Planix\AppInfo\Application;
+use OCA\Planix\Service\LabelService;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+
+/**
+ * Controller for managing labels via REST API.
+ */
+class LabelController extends Controller
+{
+
+    /**
+     * Constructor for the LabelController.
+     *
+     * @param IRequest     $request      The request object
+     * @param LabelService $labelService The label service
+     *
+     * @return void
+     */
+    public function __construct(
+        IRequest $request,
+        private LabelService $labelService,
+    ) {
+        parent::__construct(appName: Application::APP_ID, request: $request);
+    }//end __construct()
+
+    /**
+     * List all labels.
+     *
+     * @NoAdminRequired
+     *
+     * @return JSONResponse
+     */
+    public function index(): JSONResponse
+    {
+        try {
+            $labels = $this->labelService->findAll();
+            return new JSONResponse($labels);
+        } catch (\RuntimeException $e) {
+            return new JSONResponse(
+                ['error' => $e->getMessage()],
+                Http::STATUS_INTERNAL_SERVER_ERROR
+            );
+        }
+
+    }//end index()
+
+    /**
+     * Create a new label.
+     *
+     * @NoAdminRequired
+     *
+     * @return JSONResponse
+     */
+    public function create(): JSONResponse
+    {
+        $data = $this->request->getParams();
+
+        if (empty($data['name']) === true) {
+            return new JSONResponse(
+                ['error' => 'The name field is required.'],
+                Http::STATUS_BAD_REQUEST
+            );
+        }
+
+        try {
+            $label = $this->labelService->create($data);
+            return new JSONResponse($label, Http::STATUS_CREATED);
+        } catch (\RuntimeException $e) {
+            return new JSONResponse(
+                ['error' => $e->getMessage()],
+                Http::STATUS_INTERNAL_SERVER_ERROR
+            );
+        }
+
+    }//end create()
+
+    /**
+     * Delete a label by ID.
+     *
+     * @NoAdminRequired
+     *
+     * @param string $id The label UUID
+     *
+     * @return JSONResponse
+     */
+    public function destroy(string $id): JSONResponse
+    {
+        try {
+            $result = $this->labelService->delete($id);
+
+            if ($result === false) {
+                return new JSONResponse(
+                    ['error' => 'Label not found or could not be deleted.'],
+                    Http::STATUS_NOT_FOUND
+                );
+            }
+
+            return new JSONResponse(['success' => true]);
+        } catch (\RuntimeException $e) {
+            return new JSONResponse(
+                ['error' => $e->getMessage()],
+                Http::STATUS_INTERNAL_SERVER_ERROR
+            );
+        }
+
+    }//end destroy()
+}//end class

--- a/lib/Service/LabelService.php
+++ b/lib/Service/LabelService.php
@@ -1,0 +1,143 @@
+<?php
+
+/**
+ * Planix Label Service
+ *
+ * Service for managing label objects via OpenRegister.
+ *
+ * @category Service
+ * @package  OCA\Planix\Service
+ *
+ * @author    Conduction Development Team <dev@conductio.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://conduction.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Planix\Service;
+
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Service for managing label objects via OpenRegister.
+ */
+class LabelService
+{
+
+    /**
+     * The OpenRegister register slug for Planix.
+     *
+     * @var string
+     */
+    private const REGISTER = 'planix';
+
+    /**
+     * The OpenRegister schema slug for labels.
+     *
+     * @var string
+     */
+    private const SCHEMA = 'label';
+
+    /**
+     * Constructor for the LabelService.
+     *
+     * @param ContainerInterface $container The DI container
+     * @param LoggerInterface    $logger    The logger
+     *
+     * @return void
+     */
+    public function __construct(
+        private ContainerInterface $container,
+        private LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Retrieve the OpenRegister ObjectService from the container.
+     *
+     * @return object The ObjectService instance
+     *
+     * @throws \RuntimeException When OpenRegister is not available.
+     */
+    private function getObjectService(): object
+    {
+        try {
+            return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+        } catch (\Throwable $e) {
+            $this->logger->error('Planix: OpenRegister ObjectService not available', ['exception' => $e->getMessage()]);
+            throw new \RuntimeException('OpenRegister is not installed or enabled.');
+        }
+
+    }//end getObjectService()
+
+    /**
+     * List all labels.
+     *
+     * @return array<int,array<string,mixed>> The list of label objects.
+     */
+    public function findAll(): array
+    {
+        $objectService = $this->getObjectService();
+        $result = $objectService->getResultArrayForRequest(
+            register: self::REGISTER,
+            schema: self::SCHEMA,
+            requestParams: []
+        );
+
+        return ($result['results'] ?? []);
+
+    }//end findAll()
+
+    /**
+     * Create a new label.
+     *
+     * @param array<string,mixed> $data The label data (must contain 'name').
+     *
+     * @return array<string,mixed> The created label object.
+     */
+    public function create(array $data): array
+    {
+        $objectService = $this->getObjectService();
+
+        $labelData = [
+            'title' => $data['name'],
+            'color' => ($data['color'] ?? '#4376FC'),
+        ];
+
+        if (isset($data['description']) === true) {
+            $labelData['description'] = $data['description'];
+        }
+
+        return $objectService->saveObject(
+            register: self::REGISTER,
+            schema: self::SCHEMA,
+            object: $labelData
+        );
+
+    }//end create()
+
+    /**
+     * Delete a label by its ID.
+     *
+     * @param string $id The label UUID.
+     *
+     * @return bool True on success, false on failure.
+     */
+    public function delete(string $id): bool
+    {
+        $objectService = $this->getObjectService();
+
+        return $objectService->deleteObject(
+            register: self::REGISTER,
+            schema: self::SCHEMA,
+            id: $id
+        );
+
+    }//end delete()
+}//end class

--- a/lib/Service/LabelService.php
+++ b/lib/Service/LabelService.php
@@ -84,11 +84,7 @@ class LabelService
     public function findAll(): array
     {
         $objectService = $this->getObjectService();
-        $result = $objectService->getResultArrayForRequest(
-            register: self::REGISTER,
-            schema: self::SCHEMA,
-            requestParams: []
-        );
+        $result        = $objectService->getResultArrayForRequest(self::REGISTER, self::SCHEMA, []);
 
         return ($result['results'] ?? []);
 
@@ -114,11 +110,7 @@ class LabelService
             $labelData['description'] = $data['description'];
         }
 
-        return $objectService->saveObject(
-            register: self::REGISTER,
-            schema: self::SCHEMA,
-            object: $labelData
-        );
+        return $objectService->saveObject(self::REGISTER, self::SCHEMA, $labelData);
 
     }//end create()
 
@@ -133,11 +125,7 @@ class LabelService
     {
         $objectService = $this->getObjectService();
 
-        return $objectService->deleteObject(
-            register: self::REGISTER,
-            schema: self::SCHEMA,
-            id: $id
-        );
+        return $objectService->deleteObject(self::REGISTER, self::SCHEMA, $id);
 
     }//end delete()
 }//end class

--- a/openspec/changes/spec/design.md
+++ b/openspec/changes/spec/design.md
@@ -1,39 +1,18 @@
-# Admin Settings MVP
+# Label CRUD
 
-**Status**: pr-created
-**Spec reference**: [admin-user-settings](../../specs/admin-user-settings.md)
+**Status**: approved
 **Priority**: MVP
 
 ## Summary
 
-Implement the admin settings page for Planix. This is the first MVP feature that wires up
-the backend settings API with a proper frontend admin page. The user settings dialog is
-deferred to a follow-up change — this change focuses on the admin side only.
+Add label management to Planix. Labels are simple name+color objects stored in OpenRegister.
+One backend controller + one frontend component.
 
-## Scope
+## Scope (1 task)
 
-- Admin settings page under Nextcloud Administration → Planix
-- CnVersionInfoCard as the first section
-- Default columns configuration (editable ordered list)
-- OpenRegister initialization status and trigger button
-- Backend: SettingsController with read/write endpoints via IAppConfig
-- Frontend: AdminRoot.vue with CnVersionInfoCard + CnSettingsSection components
-
-## Out of scope
-
-- User settings dialog (NcAppSettingsDialog) — separate change
-- Procest bridge settings — V1, separate change
-- Notification preferences — separate change
+- Backend: LabelController with GET/POST/DELETE via OpenRegister
 
 ## Architecture
 
-- Backend: `SettingsController` exposes `GET /api/settings` and `POST /api/settings`
-- Settings stored via `OCP\IAppConfig` (server-side, admin-only)
-- Frontend: Vue 2 + `@conduction/nextcloud-vue` components
-- No new database tables or OpenRegister entities
-
-## Risks
-
-- CnVersionInfoCard and CnSettingsSection require `@conduction/nextcloud-vue` — verify the
-  dependency is declared in package.json
-- OpenRegister initialization depends on OpenRegister being installed and enabled
+- Labels stored as OpenRegister objects (use existing schema)
+- LabelController follows Controller→Service→Mapper pattern

--- a/openspec/changes/spec/design.md
+++ b/openspec/changes/spec/design.md
@@ -1,6 +1,6 @@
 # Label CRUD
 
-**Status**: approved
+**Status**: pr-created
 **Priority**: MVP
 
 ## Summary

--- a/openspec/changes/spec/tasks.md
+++ b/openspec/changes/spec/tasks.md
@@ -1,48 +1,10 @@
-# Tasks — Admin Settings MVP
+# Tasks — Label CRUD
 
-## Task 1: Backend — SettingsController admin endpoints
-**spec_ref**: admin-user-settings.md → Requirement: Admin Settings Page
-**files_likely_affected**: lib/Controller/SettingsController.php, appinfo/routes.php
+## Task 1: Backend — Label CRUD endpoints
+**spec_ref**: label-crud/design.md
+**files_likely_affected**: lib/Controller/LabelController.php (new), lib/Service/LabelService.php (new), appinfo/routes.php
 **acceptance_criteria**:
-- [x] `GET /api/settings` returns current admin settings as JSON
-- [x] `POST /api/settings` accepts a JSON body and stores values via IAppConfig
-- [x] Settings include: `default_columns` (JSON string), `allow_project_creation` (string)
-- [x] Only admin users can write settings (middleware or annotation check)
-- [x] Returns 403 for non-admin write attempts
-
-## Task 2: Backend — SettingsService business logic
-**spec_ref**: admin-user-settings.md → Data Model
-**files_likely_affected**: lib/Service/SettingsService.php
-**acceptance_criteria**:
-- [x] `getAdminSettings()` reads all planix admin keys from IAppConfig with defaults
-- [x] `setAdminSettings(array $settings)` validates and stores each key
-- [x] Default values match the spec: `default_columns = ["To Do","In Progress","Review","Done"]`
-- [x] Unknown keys are silently ignored (no error, no storage)
-
-## Task 3: Frontend — AdminRoot with CnVersionInfoCard
-**spec_ref**: admin-user-settings.md → Scenario: View admin settings
-**files_likely_affected**: src/views/settings/AdminRoot.vue, src/views/settings/Settings.vue
-**acceptance_criteria**:
-- [x] Admin settings page renders under Nextcloud Administration → Planix
-- [x] First section is CnVersionInfoCard showing app name and version
-- [x] Page uses CnSettingsSection for each logical group
-- [x] Loads current settings from `GET /api/settings` on mount
-
-## Task 4: Frontend — Default columns editor
-**spec_ref**: admin-user-settings.md → Scenario: Configure default columns
-**files_likely_affected**: src/views/settings/Settings.vue or new component
-**acceptance_criteria**:
-- [x] Shows current default columns as an editable ordered list
-- [x] Admin can add, remove, and reorder column names
-- [x] Changes are saved via `POST /api/settings` on save button click
-- [x] Shows success/error feedback after save
-
-## Task 5: Frontend — OpenRegister initialization section
-**spec_ref**: admin-user-settings.md → Scenario: OpenRegister initialization
-**files_likely_affected**: src/views/settings/Settings.vue or new component
-**acceptance_criteria**:
-- [x] Shows whether the Planix register is initialized (green check / warning)
-- [x] If not initialized, shows "Initialize register" button
-- [x] Button triggers register initialization (calls backend endpoint)
-- [x] Shows loading state during initialization
-- [x] Shows success or error result after completion
+- [ ] `GET /api/labels` lists all labels
+- [ ] `POST /api/labels` creates a label (name required, color optional)
+- [ ] `DELETE /api/labels/{id}` deletes a label
+- [ ] Returns 400 if name is missing on create

--- a/openspec/changes/spec/tasks.md
+++ b/openspec/changes/spec/tasks.md
@@ -4,7 +4,7 @@
 **spec_ref**: label-crud/design.md
 **files_likely_affected**: lib/Controller/LabelController.php (new), lib/Service/LabelService.php (new), appinfo/routes.php
 **acceptance_criteria**:
-- [ ] `GET /api/labels` lists all labels
-- [ ] `POST /api/labels` creates a label (name required, color optional)
-- [ ] `DELETE /api/labels/{id}` deletes a label
-- [ ] Returns 400 if name is missing on create
+- [x] `GET /api/labels` lists all labels
+- [x] `POST /api/labels` creates a label (name required, color optional)
+- [x] `DELETE /api/labels/{id}` deletes a label
+- [x] Returns 400 if name is missing on create

--- a/tests/unit/Controller/LabelControllerTest.php
+++ b/tests/unit/Controller/LabelControllerTest.php
@@ -1,0 +1,207 @@
+<?php
+
+/**
+ * Unit tests for LabelController.
+ *
+ * @category Test
+ * @package  OCA\Planix\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <dev@conductio.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://conduction.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Planix\Tests\Unit\Controller;
+
+use OCA\Planix\Controller\LabelController;
+use OCA\Planix\Service\LabelService;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for LabelController.
+ */
+class LabelControllerTest extends TestCase
+{
+
+    /**
+     * The controller under test.
+     *
+     * @var LabelController
+     */
+    private LabelController $controller;
+
+    /**
+     * Mock IRequest.
+     *
+     * @var IRequest&MockObject
+     */
+    private IRequest&MockObject $request;
+
+    /**
+     * Mock LabelService.
+     *
+     * @var LabelService&MockObject
+     */
+    private LabelService&MockObject $labelService;
+
+    /**
+     * Set up test fixtures.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->request      = $this->createMock(originalClassName: IRequest::class);
+        $this->labelService = $this->createMock(originalClassName: LabelService::class);
+
+        $this->controller = new LabelController(
+            request: $this->request,
+            labelService: $this->labelService,
+        );
+
+    }//end setUp()
+
+    /**
+     * Test that index() returns a JSONResponse with all labels.
+     *
+     * @return void
+     */
+    public function testIndexReturnsLabels(): void
+    {
+        $labels = [
+            ['id' => 'uuid-1', 'title' => 'Bug', 'color' => '#E74C3C'],
+            ['id' => 'uuid-2', 'title' => 'Feature', 'color' => '#4376FC'],
+        ];
+
+        $this->labelService->expects($this->once())
+            ->method('findAll')
+            ->willReturn($labels);
+
+        $result = $this->controller->index();
+
+        self::assertInstanceOf(expected: JSONResponse::class, actual: $result);
+        self::assertSame(expected: $labels, actual: $result->getData());
+        self::assertSame(expected: 200, actual: $result->getStatus());
+
+    }//end testIndexReturnsLabels()
+
+    /**
+     * Test that create() returns 400 when name is missing.
+     *
+     * @return void
+     */
+    public function testCreateReturnsBadRequestWithoutName(): void
+    {
+        $this->request->expects($this->once())
+            ->method('getParams')
+            ->willReturn(['color' => '#FF0000']);
+
+        $this->labelService->expects($this->never())
+            ->method('create');
+
+        $result = $this->controller->create();
+
+        self::assertInstanceOf(expected: JSONResponse::class, actual: $result);
+        self::assertSame(expected: Http::STATUS_BAD_REQUEST, actual: $result->getStatus());
+        self::assertArrayHasKey(key: 'error', array: $result->getData());
+
+    }//end testCreateReturnsBadRequestWithoutName()
+
+    /**
+     * Test that create() calls the service and returns 201 on success.
+     *
+     * @return void
+     */
+    public function testCreateReturnsCreatedLabel(): void
+    {
+        $params  = ['name' => 'Urgent', 'color' => '#FF0000'];
+        $created = ['id' => 'uuid-new', 'title' => 'Urgent', 'color' => '#FF0000'];
+
+        $this->request->expects($this->once())
+            ->method('getParams')
+            ->willReturn($params);
+
+        $this->labelService->expects($this->once())
+            ->method('create')
+            ->with($params)
+            ->willReturn($created);
+
+        $result = $this->controller->create();
+
+        self::assertInstanceOf(expected: JSONResponse::class, actual: $result);
+        self::assertSame(expected: Http::STATUS_CREATED, actual: $result->getStatus());
+        self::assertSame(expected: $created, actual: $result->getData());
+
+    }//end testCreateReturnsCreatedLabel()
+
+    /**
+     * Test that destroy() returns success when the label is deleted.
+     *
+     * @return void
+     */
+    public function testDestroyReturnsSuccess(): void
+    {
+        $this->labelService->expects($this->once())
+            ->method('delete')
+            ->with('uuid-1')
+            ->willReturn(true);
+
+        $result = $this->controller->destroy('uuid-1');
+
+        self::assertInstanceOf(expected: JSONResponse::class, actual: $result);
+        self::assertSame(expected: 200, actual: $result->getStatus());
+        self::assertTrue(condition: $result->getData()['success']);
+
+    }//end testDestroyReturnsSuccess()
+
+    /**
+     * Test that destroy() returns 404 when the label cannot be found.
+     *
+     * @return void
+     */
+    public function testDestroyReturnsNotFoundWhenDeleteFails(): void
+    {
+        $this->labelService->expects($this->once())
+            ->method('delete')
+            ->with('nonexistent-id')
+            ->willReturn(false);
+
+        $result = $this->controller->destroy('nonexistent-id');
+
+        self::assertInstanceOf(expected: JSONResponse::class, actual: $result);
+        self::assertSame(expected: Http::STATUS_NOT_FOUND, actual: $result->getStatus());
+        self::assertArrayHasKey(key: 'error', array: $result->getData());
+
+    }//end testDestroyReturnsNotFoundWhenDeleteFails()
+
+    /**
+     * Test that index() handles RuntimeException from the service.
+     *
+     * @return void
+     */
+    public function testIndexReturnsErrorWhenServiceThrows(): void
+    {
+        $this->labelService->expects($this->once())
+            ->method('findAll')
+            ->willThrowException(new \RuntimeException('OpenRegister is not installed or enabled.'));
+
+        $result = $this->controller->index();
+
+        self::assertInstanceOf(expected: JSONResponse::class, actual: $result);
+        self::assertSame(expected: Http::STATUS_INTERNAL_SERVER_ERROR, actual: $result->getStatus());
+        self::assertArrayHasKey(key: 'error', array: $result->getData());
+
+    }//end testIndexReturnsErrorWhenServiceThrows()
+}//end class

--- a/tests/unit/Service/LabelServiceTest.php
+++ b/tests/unit/Service/LabelServiceTest.php
@@ -70,7 +70,9 @@ class LabelServiceTest extends TestCase
 
         $this->container     = $this->createMock(originalClassName: ContainerInterface::class);
         $this->logger        = $this->createMock(originalClassName: LoggerInterface::class);
-        $this->objectService = $this->createMock(originalClassName: \stdClass::class);
+        $this->objectService = $this->getMockBuilder(className: \stdClass::class)
+            ->addMethods(['getResultArrayForRequest', 'saveObject', 'deleteObject'])
+            ->getMock();
 
         $this->container->method('get')
             ->with('OCA\OpenRegister\Service\ObjectService')
@@ -176,7 +178,7 @@ class LabelServiceTest extends TestCase
             logger: $this->logger,
         );
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(exception: \RuntimeException::class);
         $service->findAll();
 
     }//end testThrowsWhenOpenRegisterUnavailable()

--- a/tests/unit/Service/LabelServiceTest.php
+++ b/tests/unit/Service/LabelServiceTest.php
@@ -1,0 +1,183 @@
+<?php
+
+/**
+ * Unit tests for LabelService.
+ *
+ * @category Test
+ * @package  OCA\Planix\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <dev@conductio.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://conduction.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Planix\Tests\Unit\Service;
+
+use OCA\Planix\Service\LabelService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Tests for LabelService.
+ */
+class LabelServiceTest extends TestCase
+{
+
+    /**
+     * The service under test.
+     *
+     * @var LabelService
+     */
+    private LabelService $service;
+
+    /**
+     * Mock ContainerInterface.
+     *
+     * @var ContainerInterface&MockObject
+     */
+    private ContainerInterface&MockObject $container;
+
+    /**
+     * Mock LoggerInterface.
+     *
+     * @var LoggerInterface&MockObject
+     */
+    private LoggerInterface&MockObject $logger;
+
+    /**
+     * Mock ObjectService (from OpenRegister).
+     *
+     * @var MockObject
+     */
+    private MockObject $objectService;
+
+    /**
+     * Set up test fixtures.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->container     = $this->createMock(originalClassName: ContainerInterface::class);
+        $this->logger        = $this->createMock(originalClassName: LoggerInterface::class);
+        $this->objectService = $this->createMock(originalClassName: \stdClass::class);
+
+        $this->container->method('get')
+            ->with('OCA\OpenRegister\Service\ObjectService')
+            ->willReturn($this->objectService);
+
+        $this->service = new LabelService(
+            container: $this->container,
+            logger: $this->logger,
+        );
+
+    }//end setUp()
+
+    /**
+     * Test that findAll() returns the results from OpenRegister.
+     *
+     * @return void
+     */
+    public function testFindAllReturnsLabels(): void
+    {
+        $labels = [
+            ['id' => 'uuid-1', 'title' => 'Bug', 'color' => '#E74C3C'],
+            ['id' => 'uuid-2', 'title' => 'Feature', 'color' => '#4376FC'],
+        ];
+
+        $this->objectService->expects($this->once())
+            ->method('getResultArrayForRequest')
+            ->willReturn(['results' => $labels]);
+
+        $result = $this->service->findAll();
+
+        self::assertSame(expected: $labels, actual: $result);
+
+    }//end testFindAllReturnsLabels()
+
+    /**
+     * Test that create() passes correct data to OpenRegister and returns the result.
+     *
+     * @return void
+     */
+    public function testCreatePassesCorrectData(): void
+    {
+        $created = ['id' => 'uuid-new', 'title' => 'Urgent', 'color' => '#FF0000'];
+
+        $this->objectService->expects($this->once())
+            ->method('saveObject')
+            ->willReturn($created);
+
+        $result = $this->service->create(['name' => 'Urgent', 'color' => '#FF0000']);
+
+        self::assertSame(expected: $created, actual: $result);
+
+    }//end testCreatePassesCorrectData()
+
+    /**
+     * Test that create() uses the default color when none is provided.
+     *
+     * @return void
+     */
+    public function testCreateUsesDefaultColor(): void
+    {
+        $created = ['id' => 'uuid-new', 'title' => 'My Label', 'color' => '#4376FC'];
+
+        $this->objectService->expects($this->once())
+            ->method('saveObject')
+            ->willReturn($created);
+
+        $result = $this->service->create(['name' => 'My Label']);
+
+        self::assertSame(expected: '#4376FC', actual: $result['color']);
+
+    }//end testCreateUsesDefaultColor()
+
+    /**
+     * Test that delete() calls deleteObject and returns the result.
+     *
+     * @return void
+     */
+    public function testDeleteReturnsTrueOnSuccess(): void
+    {
+        $this->objectService->expects($this->once())
+            ->method('deleteObject')
+            ->willReturn(true);
+
+        $result = $this->service->delete('uuid-1');
+
+        self::assertTrue(condition: $result);
+
+    }//end testDeleteReturnsTrueOnSuccess()
+
+    /**
+     * Test that a RuntimeException is thrown when OpenRegister is unavailable.
+     *
+     * @return void
+     */
+    public function testThrowsWhenOpenRegisterUnavailable(): void
+    {
+        $container = $this->createMock(originalClassName: ContainerInterface::class);
+        $container->method('get')
+            ->willThrowException(new \Exception('Service not found'));
+
+        $service = new LabelService(
+            container: $container,
+            logger: $this->logger,
+        );
+
+        $this->expectException(\RuntimeException::class);
+        $service->findAll();
+
+    }//end testThrowsWhenOpenRegisterUnavailable()
+}//end class


### PR DESCRIPTION
Closes #84

## Summary
Adds a LabelController and LabelService for managing labels (name + color) via OpenRegister.
Three REST endpoints are exposed: GET /api/labels (list all), POST /api/labels (create with
required name and optional color), and DELETE /api/labels/{id} (delete by UUID). The controller
returns 400 when the name field is missing on create.

## Spec Reference
- Issue: #84
- Spec: `openspec/changes/spec/design.md`

## Changes
- `lib/Controller/LabelController.php` — new controller with index, create, destroy actions
- `lib/Service/LabelService.php` — new service wrapping OpenRegister ObjectService for label CRUD
- `appinfo/routes.php` — added GET/POST/DELETE routes for /api/labels
- `openspec/changes/spec/` — spec files copied into repo, tasks marked complete

## Test Coverage
- `tests/unit/Controller/LabelControllerTest.php` — 6 tests: index returns labels, create validates name (400), create returns 201, destroy success/not-found, error handling
- `tests/unit/Service/LabelServiceTest.php` — 5 tests: findAll, create with/without color, delete, RuntimeException when OpenRegister unavailable