### PR TITLE
feat: Label CRUD endpoints

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -15,6 +15,11 @@ return [
         // Health check endpoint.
         ['name' => 'health#index', 'url' => '/api/health', 'verb' => 'GET'],
 
+        // Label CRUD endpoints.
+        ['name' => 'label#index',   'url' => '/api/labels',      'verb' => 'GET'],
+        ['name' => 'label#create',  'url' => '/api/labels',      'verb' => 'POST'],
+        ['name' => 'label#destroy', 'url' => '/api/labels/{id}', 'verb' => 'DELETE'],
+
         // SPA catch-all — same controller as the index route; must use a distinct route name
         // (duplicate names replace the earlier route in Symfony, which breaks GET /).
         ['name' => 'dashboard#catchAll', 'url' => '/{path}', 'verb' => 'GET', 'requirements' => ['path' => '.+'], 'defaults' => ['path' => '']],

--- a/lib/Controller/LabelController.php
+++ b/lib/Controller/LabelController.php
@@ -1,0 +1,139 @@
+<?php
+
+/**
+ * Planix Label Controller
+ *
+ * Controller for label CRUD endpoints.
+ *
+ * @category Controller
+ * @package  OCA\Planix\Controller
+ * @spec     openspec/changes/label-crud/tasks.md#task-1
+ *
+ * @author    Conduction Development Team <dev@conductio.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://conduction.nl
+ */
+
+// SPDX-License-Identifier: EUPL-1.2
+// Copyright (C) 2026 Conduction B.V.
+declare(strict_types=1);
+
+namespace OCA\Planix\Controller;
+
+use InvalidArgumentException;
+use OCA\Planix\AppInfo\Application;
+use OCA\Planix\Service\LabelService;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+use RuntimeException;
+
+/**
+ * Controller for label CRUD endpoints.
+ *
+ * @spec openspec/changes/label-crud/tasks.md#task-1
+ */
+class LabelController extends Controller
+{
+    /**
+     * Constructor for the LabelController.
+     *
+     * @param IRequest     $request      The request object
+     * @param LabelService $labelService The label service
+     *
+     * @spec openspec/changes/label-crud/tasks.md#task-1
+     *
+     * @return void
+     */
+    public function __construct(
+        IRequest $request,
+        private LabelService $labelService,
+    ) {
+        parent::__construct(appName: Application::APP_ID, request: $request);
+
+    }//end __construct()
+
+    /**
+     * List all labels.
+     *
+     * @NoAdminRequired
+     *
+     * @spec openspec/changes/label-crud/tasks.md#task-1
+     *
+     * @return JSONResponse
+     */
+    public function index(): JSONResponse
+    {
+        try {
+            $labels = $this->labelService->findAll();
+            return new JSONResponse($labels);
+        } catch (RuntimeException $e) {
+            return new JSONResponse(
+                ['error' => $e->getMessage()],
+                Http::STATUS_INTERNAL_SERVER_ERROR
+            );
+        }
+
+    }//end index()
+
+    /**
+     * Create a new label.
+     *
+     * @NoAdminRequired
+     *
+     * @spec openspec/changes/label-crud/tasks.md#task-1
+     *
+     * @return JSONResponse
+     */
+    public function create(): JSONResponse
+    {
+        try {
+            $data  = $this->request->getParams();
+            $label = $this->labelService->create($data);
+
+            return new JSONResponse($label, Http::STATUS_CREATED);
+        } catch (InvalidArgumentException $e) {
+            return new JSONResponse(
+                ['error' => $e->getMessage()],
+                Http::STATUS_BAD_REQUEST
+            );
+        } catch (RuntimeException $e) {
+            return new JSONResponse(
+                ['error' => $e->getMessage()],
+                Http::STATUS_INTERNAL_SERVER_ERROR
+            );
+        }
+
+    }//end create()
+
+    /**
+     * Delete a label by its UUID.
+     *
+     * @param string $id The UUID of the label
+     *
+     * @NoAdminRequired
+     *
+     * @return JSONResponse
+     *
+     * @spec openspec/changes/label-crud/tasks.md#task-1
+     */
+    public function destroy(string $id): JSONResponse
+    {
+        try {
+            $this->labelService->delete($id);
+
+            return new JSONResponse(['success' => true]);
+        } catch (RuntimeException $e) {
+            return new JSONResponse(
+                ['error' => $e->getMessage()],
+                Http::STATUS_INTERNAL_SERVER_ERROR
+            );
+        }
+
+    }//end destroy()
+}//end class

--- a/lib/Service/LabelService.php
+++ b/lib/Service/LabelService.php
@@ -1,0 +1,162 @@
+<?php
+
+/**
+ * Planix Label Service
+ *
+ * Service for managing label objects via OpenRegister.
+ *
+ * @category Service
+ * @package  OCA\Planix\Service
+ * @spec     openspec/changes/label-crud/tasks.md#task-1
+ *
+ * @author    Conduction Development Team <dev@conductio.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://conduction.nl
+ */
+
+// SPDX-License-Identifier: EUPL-1.2
+// Copyright (C) 2026 Conduction B.V.
+declare(strict_types=1);
+
+namespace OCA\Planix\Service;
+
+use InvalidArgumentException;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+/**
+ * Service for managing label objects via OpenRegister.
+ *
+ * @spec openspec/changes/label-crud/tasks.md#task-1
+ */
+class LabelService
+{
+
+    /**
+     * The OpenRegister register name for Planix.
+     *
+     * @var string
+     */
+    private const REGISTER = 'planix';
+
+    /**
+     * The OpenRegister schema slug for labels.
+     *
+     * @var string
+     */
+    private const SCHEMA = 'label';
+
+    /**
+     * Constructor for the LabelService.
+     *
+     * @param ContainerInterface $container The DI container
+     * @param LoggerInterface    $logger    The logger
+     *
+     * @return void
+     */
+    public function __construct(
+        private ContainerInterface $container,
+        private LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Retrieve the OpenRegister ObjectService from the DI container.
+     *
+     * @spec openspec/changes/label-crud/tasks.md#task-1
+     *
+     * @return object The ObjectService instance
+     *
+     * @throws RuntimeException When OpenRegister is not available.
+     */
+    private function getObjectService(): object
+    {
+        try {
+            return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+        } catch (\Throwable $e) {
+            $this->logger->error('Planix: OpenRegister ObjectService not available', ['exception' => $e->getMessage()]);
+            throw new RuntimeException('OpenRegister is not installed or enabled.');
+        }
+
+    }//end getObjectService()
+
+    /**
+     * List all labels.
+     *
+     * @spec openspec/changes/label-crud/tasks.md#task-1
+     *
+     * @return array<string,mixed> Paginated result from OpenRegister
+     */
+    public function findAll(): array
+    {
+        $objectService = $this->getObjectService();
+
+        return $objectService->getResultArrayForRequest(
+            self::REGISTER,
+            self::SCHEMA,
+            [],
+        );
+
+    }//end findAll()
+
+    /**
+     * Create a new label.
+     *
+     * @param array<string,mixed> $data Label data (name, color, description)
+     *
+     * @spec openspec/changes/label-crud/tasks.md#task-1
+     *
+     * @return array<string,mixed> The created label object
+     *
+     * @throws InvalidArgumentException When name is missing.
+     */
+    public function create(array $data): array
+    {
+        if (empty($data['name']) === true && empty($data['title']) === true) {
+            throw new InvalidArgumentException('Label name is required.');
+        }
+
+        // Normalise: accept both "name" and "title" — OpenRegister schema uses "title".
+        if (isset($data['name']) === true && isset($data['title']) === false) {
+            $data['title'] = $data['name'];
+            unset($data['name']);
+        }
+
+        $objectService = $this->getObjectService();
+
+        return $objectService->saveObject(
+            self::REGISTER,
+            self::SCHEMA,
+            $data,
+        );
+
+    }//end create()
+
+    /**
+     * Delete a label by its UUID.
+     *
+     * @param string $id The UUID of the label to delete
+     *
+     * @spec openspec/changes/label-crud/tasks.md#task-1
+     *
+     * @return bool True on success
+     *
+     * @throws RuntimeException When deletion fails.
+     */
+    public function delete(string $id): bool
+    {
+        $objectService = $this->getObjectService();
+
+        return $objectService->deleteObject(
+            self::REGISTER,
+            self::SCHEMA,
+            $id,
+        );
+
+    }//end delete()
+}//end class

--- a/openspec/changes/label-crud/design.md
+++ b/openspec/changes/label-crud/design.md
@@ -1,0 +1,18 @@
+# Label CRUD
+
+**Status**: approved
+**Priority**: MVP
+
+## Summary
+
+Add label management to Planix. Labels are simple name+color objects stored in OpenRegister.
+One backend controller + one frontend component.
+
+## Scope (1 task)
+
+- Backend: LabelController with GET/POST/DELETE via OpenRegister
+
+## Architecture
+
+- Labels stored as OpenRegister objects (use existing schema)
+- LabelController follows Controller→Service→Mapper pattern

--- a/openspec/changes/label-crud/design.md
+++ b/openspec/changes/label-crud/design.md
@@ -1,6 +1,6 @@
 # Label CRUD
 
-**Status**: approved
+**Status**: pr-created
 **Priority**: MVP
 
 ## Summary

--- a/openspec/changes/label-crud/tasks.md
+++ b/openspec/changes/label-crud/tasks.md
@@ -4,7 +4,7 @@
 **spec_ref**: label-crud/design.md
 **files_likely_affected**: lib/Controller/LabelController.php (new), lib/Service/LabelService.php (new), appinfo/routes.php
 **acceptance_criteria**:
-- [ ] `GET /api/labels` lists all labels
-- [ ] `POST /api/labels` creates a label (name required, color optional)
-- [ ] `DELETE /api/labels/{id}` deletes a label
-- [ ] Returns 400 if name is missing on create
+- [x] `GET /api/labels` lists all labels
+- [x] `POST /api/labels` creates a label (name required, color optional)
+- [x] `DELETE /api/labels/{id}` deletes a label
+- [x] Returns 400 if name is missing on create

--- a/openspec/changes/label-crud/tasks.md
+++ b/openspec/changes/label-crud/tasks.md
@@ -1,0 +1,10 @@
+# Tasks — Label CRUD
+
+## Task 1: Backend — Label CRUD endpoints
+**spec_ref**: label-crud/design.md
+**files_likely_affected**: lib/Controller/LabelController.php (new), lib/Service/LabelService.php (new), appinfo/routes.php
+**acceptance_criteria**:
+- [ ] `GET /api/labels` lists all labels
+- [ ] `POST /api/labels` creates a label (name required, color optional)
+- [ ] `DELETE /api/labels/{id}` deletes a label
+- [ ] Returns 400 if name is missing on create

--- a/tests/unit/Controller/LabelControllerTest.php
+++ b/tests/unit/Controller/LabelControllerTest.php
@@ -1,0 +1,209 @@
+<?php
+
+/**
+ * Unit tests for LabelController.
+ *
+ * @category Test
+ * @package  OCA\Planix\Tests\Unit\Controller
+ * @spec     openspec/changes/label-crud/tasks.md#task-1
+ *
+ * @author    Conduction Development Team <dev@conductio.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://conduction.nl
+ */
+
+// SPDX-License-Identifier: EUPL-1.2
+// Copyright (C) 2026 Conduction B.V.
+
+declare(strict_types=1);
+
+namespace OCA\Planix\Tests\Unit\Controller;
+
+use OCA\Planix\Controller\LabelController;
+use OCA\Planix\Service\LabelService;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for LabelController.
+ *
+ * @spec openspec/changes/label-crud/tasks.md#task-1
+ */
+class LabelControllerTest extends TestCase
+{
+
+    /**
+     * The controller under test.
+     *
+     * @var LabelController
+     */
+    private LabelController $controller;
+
+    /**
+     * Mock IRequest.
+     *
+     * @var IRequest&MockObject
+     */
+    private IRequest&MockObject $request;
+
+    /**
+     * Mock LabelService.
+     *
+     * @var LabelService&MockObject
+     */
+    private LabelService&MockObject $labelService;
+
+    /**
+     * Set up test fixtures.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->request      = $this->createMock(originalClassName: IRequest::class);
+        $this->labelService = $this->createMock(originalClassName: LabelService::class);
+
+        $this->controller = new LabelController(
+            request: $this->request,
+            labelService: $this->labelService,
+        );
+
+    }//end setUp()
+
+    /**
+     * Test that index() returns a JSONResponse with all labels.
+     *
+     * @spec openspec/changes/label-crud/tasks.md#task-1
+     *
+     * @return void
+     */
+    public function testIndexReturnsLabels(): void
+    {
+        $labels = [
+            'results' => [
+                ['id' => 'uuid-1', 'title' => 'Bug', 'color' => '#E74C3C'],
+                ['id' => 'uuid-2', 'title' => 'Feature', 'color' => '#4376FC'],
+            ],
+        ];
+
+        $this->labelService->expects($this->once())
+            ->method('findAll')
+            ->willReturn($labels);
+
+        $result = $this->controller->index();
+
+        self::assertInstanceOf(expected: JSONResponse::class, actual: $result);
+        self::assertSame(expected: 200, actual: $result->getStatus());
+        self::assertSame(expected: $labels, actual: $result->getData());
+
+    }//end testIndexReturnsLabels()
+
+    /**
+     * Test that create() returns 201 with the created label.
+     *
+     * @spec openspec/changes/label-crud/tasks.md#task-1
+     *
+     * @return void
+     */
+    public function testCreateReturnsCreatedLabel(): void
+    {
+        $params = ['name' => 'Urgent', 'color' => '#FF0000'];
+        $saved  = ['id' => 'uuid-new', 'title' => 'Urgent', 'color' => '#FF0000'];
+
+        $this->request->expects($this->once())
+            ->method('getParams')
+            ->willReturn($params);
+
+        $this->labelService->expects($this->once())
+            ->method('create')
+            ->with($params)
+            ->willReturn($saved);
+
+        $result = $this->controller->create();
+
+        self::assertInstanceOf(expected: JSONResponse::class, actual: $result);
+        self::assertSame(expected: Http::STATUS_CREATED, actual: $result->getStatus());
+        self::assertSame(expected: $saved, actual: $result->getData());
+
+    }//end testCreateReturnsCreatedLabel()
+
+    /**
+     * Test that create() returns 400 when name is missing.
+     *
+     * @spec openspec/changes/label-crud/tasks.md#task-1
+     *
+     * @return void
+     */
+    public function testCreateReturnsBadRequestWhenNameMissing(): void
+    {
+        $params = ['color' => '#FF0000'];
+
+        $this->request->expects($this->once())
+            ->method('getParams')
+            ->willReturn($params);
+
+        $this->labelService->expects($this->once())
+            ->method('create')
+            ->with($params)
+            ->willThrowException(new \InvalidArgumentException('Label name is required.'));
+
+        $result = $this->controller->create();
+
+        self::assertInstanceOf(expected: JSONResponse::class, actual: $result);
+        self::assertSame(expected: Http::STATUS_BAD_REQUEST, actual: $result->getStatus());
+        self::assertArrayHasKey(key: 'error', array: $result->getData());
+
+    }//end testCreateReturnsBadRequestWhenNameMissing()
+
+    /**
+     * Test that destroy() returns success response.
+     *
+     * @spec openspec/changes/label-crud/tasks.md#task-1
+     *
+     * @return void
+     */
+    public function testDestroyReturnsSuccess(): void
+    {
+        $this->labelService->expects($this->once())
+            ->method('delete')
+            ->with('uuid-1')
+            ->willReturn(true);
+
+        $result = $this->controller->destroy('uuid-1');
+
+        self::assertInstanceOf(expected: JSONResponse::class, actual: $result);
+        self::assertSame(expected: 200, actual: $result->getStatus());
+        self::assertTrue(condition: $result->getData()['success']);
+
+    }//end testDestroyReturnsSuccess()
+
+    /**
+     * Test that index() returns 500 when OpenRegister is unavailable.
+     *
+     * @spec openspec/changes/label-crud/tasks.md#task-1
+     *
+     * @return void
+     */
+    public function testIndexReturnsErrorWhenOpenRegisterUnavailable(): void
+    {
+        $this->labelService->expects($this->once())
+            ->method('findAll')
+            ->willThrowException(new \RuntimeException('OpenRegister is not installed or enabled.'));
+
+        $result = $this->controller->index();
+
+        self::assertInstanceOf(expected: JSONResponse::class, actual: $result);
+        self::assertSame(expected: Http::STATUS_INTERNAL_SERVER_ERROR, actual: $result->getStatus());
+        self::assertArrayHasKey(key: 'error', array: $result->getData());
+
+    }//end testIndexReturnsErrorWhenOpenRegisterUnavailable()
+}//end class

--- a/tests/unit/Service/LabelServiceTest.php
+++ b/tests/unit/Service/LabelServiceTest.php
@@ -1,0 +1,201 @@
+<?php
+
+/**
+ * Unit tests for LabelService.
+ *
+ * @category Test
+ * @package  OCA\Planix\Tests\Unit\Service
+ * @spec     openspec/changes/label-crud/tasks.md#task-1
+ *
+ * @author    Conduction Development Team <dev@conductio.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://conduction.nl
+ */
+
+// SPDX-License-Identifier: EUPL-1.2
+// Copyright (C) 2026 Conduction B.V.
+
+declare(strict_types=1);
+
+namespace OCA\Planix\Tests\Unit\Service;
+
+use OCA\Planix\Service\LabelService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Tests for LabelService.
+ *
+ * @spec openspec/changes/label-crud/tasks.md#task-1
+ */
+class LabelServiceTest extends TestCase
+{
+
+    /**
+     * The service under test.
+     *
+     * @var LabelService
+     */
+    private LabelService $service;
+
+    /**
+     * Mock ContainerInterface.
+     *
+     * @var ContainerInterface&MockObject
+     */
+    private ContainerInterface&MockObject $container;
+
+    /**
+     * Mock LoggerInterface.
+     *
+     * @var LoggerInterface&MockObject
+     */
+    private LoggerInterface&MockObject $logger;
+
+    /**
+     * Mock ObjectService (dynamic mock).
+     *
+     * @var MockObject
+     */
+    private MockObject $objectService;
+
+    /**
+     * Set up test fixtures.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->container     = $this->createMock(originalClassName: ContainerInterface::class);
+        $this->logger        = $this->createMock(originalClassName: LoggerInterface::class);
+        $this->objectService = $this->getMockBuilder(\stdClass::class)
+            ->addMethods(['getResultArrayForRequest', 'saveObject', 'deleteObject'])
+            ->getMock();
+
+        $this->container->method('get')
+            ->with('OCA\OpenRegister\Service\ObjectService')
+            ->willReturn($this->objectService);
+
+        $this->service = new LabelService(
+            container: $this->container,
+            logger: $this->logger,
+        );
+
+    }//end setUp()
+
+    /**
+     * Test that findAll() returns labels from OpenRegister.
+     *
+     * @spec openspec/changes/label-crud/tasks.md#task-1
+     *
+     * @return void
+     */
+    public function testFindAllReturnsLabels(): void
+    {
+        $expected = [
+            'results' => [
+                ['id' => 'uuid-1', 'title' => 'Bug', 'color' => '#E74C3C'],
+            ],
+        ];
+
+        $this->objectService->expects($this->once())
+            ->method('getResultArrayForRequest')
+            ->with('planix', 'label', [])
+            ->willReturn($expected);
+
+        $result = $this->service->findAll();
+
+        self::assertSame(expected: $expected, actual: $result);
+
+    }//end testFindAllReturnsLabels()
+
+    /**
+     * Test that create() saves a label and normalises the name field to title.
+     *
+     * @spec openspec/changes/label-crud/tasks.md#task-1
+     *
+     * @return void
+     */
+    public function testCreateSavesLabelWithNameNormalisedToTitle(): void
+    {
+        $input    = ['name' => 'Urgent', 'color' => '#FF0000'];
+        $expected = ['id' => 'uuid-new', 'title' => 'Urgent', 'color' => '#FF0000'];
+
+        $this->objectService->expects($this->once())
+            ->method('saveObject')
+            ->with('planix', 'label', ['title' => 'Urgent', 'color' => '#FF0000'])
+            ->willReturn($expected);
+
+        $result = $this->service->create($input);
+
+        self::assertSame(expected: $expected, actual: $result);
+
+    }//end testCreateSavesLabelWithNameNormalisedToTitle()
+
+    /**
+     * Test that create() throws InvalidArgumentException when name is missing.
+     *
+     * @spec openspec/changes/label-crud/tasks.md#task-1
+     *
+     * @return void
+     */
+    public function testCreateThrowsWhenNameMissing(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Label name is required.');
+
+        $this->service->create(['color' => '#FF0000']);
+
+    }//end testCreateThrowsWhenNameMissing()
+
+    /**
+     * Test that delete() calls deleteObject on OpenRegister.
+     *
+     * @spec openspec/changes/label-crud/tasks.md#task-1
+     *
+     * @return void
+     */
+    public function testDeleteCallsObjectService(): void
+    {
+        $this->objectService->expects($this->once())
+            ->method('deleteObject')
+            ->with('planix', 'label', 'uuid-1')
+            ->willReturn(true);
+
+        $result = $this->service->delete('uuid-1');
+
+        self::assertTrue(condition: $result);
+
+    }//end testDeleteCallsObjectService()
+
+    /**
+     * Test that findAll() throws RuntimeException when OpenRegister is unavailable.
+     *
+     * @spec openspec/changes/label-crud/tasks.md#task-1
+     *
+     * @return void
+     */
+    public function testFindAllThrowsWhenOpenRegisterUnavailable(): void
+    {
+        $container = $this->createMock(originalClassName: ContainerInterface::class);
+        $container->method('get')
+            ->willThrowException(new \RuntimeException('Service not found'));
+
+        $service = new LabelService(
+            container: $container,
+            logger: $this->logger,
+        );
+
+        $this->expectException(\RuntimeException::class);
+        $service->findAll();
+
+    }//end testFindAllThrowsWhenOpenRegisterUnavailable()
+}//end class


### PR DESCRIPTION
Closes #84

## Summary
Adds label management endpoints to Planix. A new `LabelController` and `LabelService` provide
GET /api/labels (list all), POST /api/labels (create with required name), and DELETE /api/labels/{id}
(remove by UUID). The service delegates to OpenRegister's ObjectService for persistence, following
the existing Controller→Service pattern established by SettingsController.

## Spec Reference
- Issue: #84
- Spec: `openspec/changes/label-crud/design.md`

## Changes
- `appinfo/routes.php` — added three label routes (GET, POST, DELETE)
- `lib/Controller/LabelController.php` — new controller handling HTTP layer, validation errors (400), and runtime errors (500)
- `lib/Service/LabelService.php` — new service wrapping OpenRegister ObjectService for label CRUD; normalises `name` → `title` for schema compatibility
- `openspec/changes/label-crud/design.md` — spec copied into repo, status updated to pr-created
- `openspec/changes/label-crud/tasks.md` — all acceptance criteria marked complete

## Test Coverage
- `tests/unit/Controller/LabelControllerTest.php` — 5 tests: index returns labels, create returns 201, create returns 400 on missing name, destroy returns success, index returns 500 when OpenRegister unavailable
- `tests/unit/Service/LabelServiceTest.php` — 5 tests: findAll delegates to ObjectService, create normalises name→title, create throws on missing name, delete delegates to ObjectService, findAll throws when OpenRegister unavailable