### PR TITLE
feat: add health check endpoint GET /api/health

### DIFF
--- a/lib/Controller/HealthController.php
+++ b/lib/Controller/HealthController.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * Planix Health Controller
+ *
+ * Provides a public health check endpoint for load balancers and monitoring.
+ *
+ * @spec openspec/changes/status-api/tasks.md#task-1
+ *
+ * @category Controller
+ * @package  OCA\Planix\Controller
+ *
+ * @author    Conduction Development Team <dev@conductio.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://conduction.nl
+ */
+
+// SPDX-License-Identifier: EUPL-1.2
+// Copyright (C) 2026 Conduction B.V.
+
+declare(strict_types=1);
+
+namespace OCA\Planix\Controller;
+
+use OCA\Planix\AppInfo\Application;
+use OCP\App\IAppManager;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+
+/**
+ * Controller for the health check endpoint.
+ *
+ * @spec openspec/changes/status-api/tasks.md#task-1
+ */
+class HealthController extends Controller
+{
+    /**
+     * Constructor for the HealthController.
+     *
+     * @spec openspec/changes/status-api/tasks.md#task-1
+     *
+     * @param IRequest    $request    The request object
+     * @param IAppManager $appManager The app manager for checking installed apps
+     *
+     * @return void
+     */
+    public function __construct(
+        IRequest $request,
+        private IAppManager $appManager,
+    ) {
+        parent::__construct(appName: Application::APP_ID, request: $request);
+    }//end __construct()
+
+    /**
+     * Return the health status of the Planix application.
+     *
+     * Returns HTTP 200 when healthy (OpenRegister available),
+     * HTTP 503 when OpenRegister is unavailable.
+     *
+     * @spec openspec/changes/status-api/tasks.md#task-1
+     *
+     * @PublicPage
+     * @NoCSRFRequired
+     *
+     * @return JSONResponse
+     */
+    public function index(): JSONResponse
+    {
+        $openRegisterAvailable = $this->appManager->isInstalled('openregister');
+        $version               = $this->appManager->getAppVersion(Application::APP_ID);
+
+        $status     = $openRegisterAvailable ? 'ok' : 'degraded';
+        $httpStatus = $openRegisterAvailable
+            ? Http::STATUS_OK
+            : Http::STATUS_SERVICE_UNAVAILABLE;
+
+        return new JSONResponse(
+            [
+                'status'                => $status,
+                'version'               => $version,
+                'openRegisterAvailable' => $openRegisterAvailable,
+            ],
+            $httpStatus
+        );
+    }//end index()
+}//end class

--- a/lib/Controller/HealthController.php
+++ b/lib/Controller/HealthController.php
@@ -5,6 +5,9 @@
  *
  * Provides a public health check endpoint for load balancers and monitoring.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * Copyright (C) 2026 Conduction B.V.
+ *
  * @spec openspec/changes/status-api/tasks.md#task-1
  *
  * @category Controller
@@ -18,9 +21,6 @@
  *
  * @link https://conduction.nl
  */
-
-// SPDX-License-Identifier: EUPL-1.2
-// Copyright (C) 2026 Conduction B.V.
 
 declare(strict_types=1);
 
@@ -43,10 +43,10 @@ class HealthController extends Controller
     /**
      * Constructor for the HealthController.
      *
-     * @spec openspec/changes/status-api/tasks.md#task-1
-     *
      * @param IRequest    $request    The request object
      * @param IAppManager $appManager The app manager for checking installed apps
+     *
+     * @spec openspec/changes/status-api/tasks.md#task-1
      *
      * @return void
      */
@@ -63,28 +63,31 @@ class HealthController extends Controller
      * Returns HTTP 200 when healthy (OpenRegister available),
      * HTTP 503 when OpenRegister is unavailable.
      *
-     * @spec openspec/changes/status-api/tasks.md#task-1
-     *
      * @PublicPage
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/status-api/tasks.md#task-1
      *
      * @return JSONResponse
      */
     public function index(): JSONResponse
     {
-        $openRegisterAvailable = $this->appManager->isInstalled('openregister');
-        $version               = $this->appManager->getAppVersion(Application::APP_ID);
+        $hasRegister = $this->appManager->isInstalled('openregister');
+        $version     = $this->appManager->getAppVersion(Application::APP_ID);
 
-        $status     = $openRegisterAvailable ? 'ok' : 'degraded';
-        $httpStatus = $openRegisterAvailable
-            ? Http::STATUS_OK
-            : Http::STATUS_SERVICE_UNAVAILABLE;
+        $status     = 'degraded';
+        $httpStatus = Http::STATUS_SERVICE_UNAVAILABLE;
+
+        if ($hasRegister === true) {
+            $status     = 'ok';
+            $httpStatus = Http::STATUS_OK;
+        }
 
         return new JSONResponse(
             [
                 'status'                => $status,
                 'version'               => $version,
-                'openRegisterAvailable' => $openRegisterAvailable,
+                'openRegisterAvailable' => $hasRegister,
             ],
             $httpStatus
         );

--- a/openspec/changes/status-api/design.md
+++ b/openspec/changes/status-api/design.md
@@ -1,0 +1,9 @@
+# Status API
+
+**Status**: approved
+
+## Summary
+Add a health check endpoint to Planix per ADR-015 (Prometheus metrics & health).
+
+## Scope (1 task)
+- Backend: HealthController with GET /api/health returning JSON status

--- a/openspec/changes/status-api/design.md
+++ b/openspec/changes/status-api/design.md
@@ -1,6 +1,6 @@
 # Status API
 
-**Status**: approved
+**Status**: pr-created
 
 ## Summary
 Add a health check endpoint to Planix per ADR-015 (Prometheus metrics & health).

--- a/openspec/changes/status-api/tasks.md
+++ b/openspec/changes/status-api/tasks.md
@@ -4,6 +4,6 @@
 **spec_ref**: status-api/design.md
 **files_likely_affected**: lib/Controller/HealthController.php (new), appinfo/routes.php
 **acceptance_criteria**:
-- [ ] `GET /api/health` returns JSON with `status`, `version`, and `openRegisterAvailable` fields
-- [ ] Endpoint is public (no auth required) for load balancer use
-- [ ] Returns HTTP 200 when healthy, 503 when OpenRegister unavailable
+- [x] `GET /api/health` returns JSON with `status`, `version`, and `openRegisterAvailable` fields
+- [x] Endpoint is public (no auth required) for load balancer use
+- [x] Returns HTTP 200 when healthy, 503 when OpenRegister unavailable

--- a/openspec/changes/status-api/tasks.md
+++ b/openspec/changes/status-api/tasks.md
@@ -1,0 +1,9 @@
+# Tasks — Status API
+
+## Task 1: Backend — Health check endpoint
+**spec_ref**: status-api/design.md
+**files_likely_affected**: lib/Controller/HealthController.php (new), appinfo/routes.php
+**acceptance_criteria**:
+- [ ] `GET /api/health` returns JSON with `status`, `version`, and `openRegisterAvailable` fields
+- [ ] Endpoint is public (no auth required) for load balancer use
+- [ ] Returns HTTP 200 when healthy, 503 when OpenRegister unavailable

--- a/tests/unit/Controller/HealthControllerTest.php
+++ b/tests/unit/Controller/HealthControllerTest.php
@@ -3,6 +3,9 @@
 /**
  * Unit tests for HealthController.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * Copyright (C) 2026 Conduction B.V.
+ *
  * @spec openspec/changes/status-api/tasks.md#task-1
  *
  * @category Test
@@ -16,9 +19,6 @@
  *
  * @link https://conduction.nl
  */
-
-// SPDX-License-Identifier: EUPL-1.2
-// Copyright (C) 2026 Conduction B.V.
 
 declare(strict_types=1);
 

--- a/tests/unit/Controller/HealthControllerTest.php
+++ b/tests/unit/Controller/HealthControllerTest.php
@@ -1,0 +1,164 @@
+<?php
+
+/**
+ * Unit tests for HealthController.
+ *
+ * @spec openspec/changes/status-api/tasks.md#task-1
+ *
+ * @category Test
+ * @package  OCA\Planix\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <dev@conductio.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://conduction.nl
+ */
+
+// SPDX-License-Identifier: EUPL-1.2
+// Copyright (C) 2026 Conduction B.V.
+
+declare(strict_types=1);
+
+namespace OCA\Planix\Tests\Unit\Controller;
+
+use OCA\Planix\Controller\HealthController;
+use OCP\App\IAppManager;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for HealthController.
+ *
+ * @spec openspec/changes/status-api/tasks.md#task-1
+ */
+class HealthControllerTest extends TestCase
+{
+
+    /**
+     * The controller under test.
+     *
+     * @var HealthController
+     */
+    private HealthController $controller;
+
+    /**
+     * Mock IRequest.
+     *
+     * @var IRequest&MockObject
+     */
+    private IRequest&MockObject $request;
+
+    /**
+     * Mock IAppManager.
+     *
+     * @var IAppManager&MockObject
+     */
+    private IAppManager&MockObject $appManager;
+
+    /**
+     * Set up test fixtures.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->request    = $this->createMock(originalClassName: IRequest::class);
+        $this->appManager = $this->createMock(originalClassName: IAppManager::class);
+
+        $this->controller = new HealthController(
+            request: $this->request,
+            appManager: $this->appManager,
+        );
+
+    }//end setUp()
+
+    /**
+     * Test that index() returns 200 with status ok when OpenRegister is available.
+     *
+     * @spec openspec/changes/status-api/tasks.md#task-1
+     *
+     * @return void
+     */
+    public function testIndexReturnsOkWhenOpenRegisterAvailable(): void
+    {
+        $this->appManager->expects($this->once())
+            ->method('isInstalled')
+            ->with('openregister')
+            ->willReturn(true);
+
+        $this->appManager->expects($this->once())
+            ->method('getAppVersion')
+            ->with('planix')
+            ->willReturn('0.2.1');
+
+        $result = $this->controller->index();
+
+        self::assertInstanceOf(expected: JSONResponse::class, actual: $result);
+        self::assertSame(expected: Http::STATUS_OK, actual: $result->getStatus());
+
+        $data = $result->getData();
+        self::assertSame(expected: 'ok', actual: $data['status']);
+        self::assertSame(expected: '0.2.1', actual: $data['version']);
+        self::assertTrue(condition: $data['openRegisterAvailable']);
+
+    }//end testIndexReturnsOkWhenOpenRegisterAvailable()
+
+    /**
+     * Test that index() returns 503 with degraded status when OpenRegister is unavailable.
+     *
+     * @spec openspec/changes/status-api/tasks.md#task-1
+     *
+     * @return void
+     */
+    public function testIndexReturnsDegradedWhenOpenRegisterUnavailable(): void
+    {
+        $this->appManager->expects($this->once())
+            ->method('isInstalled')
+            ->with('openregister')
+            ->willReturn(false);
+
+        $this->appManager->expects($this->once())
+            ->method('getAppVersion')
+            ->with('planix')
+            ->willReturn('0.2.1');
+
+        $result = $this->controller->index();
+
+        self::assertInstanceOf(expected: JSONResponse::class, actual: $result);
+        self::assertSame(expected: Http::STATUS_SERVICE_UNAVAILABLE, actual: $result->getStatus());
+
+        $data = $result->getData();
+        self::assertSame(expected: 'degraded', actual: $data['status']);
+        self::assertFalse(condition: $data['openRegisterAvailable']);
+
+    }//end testIndexReturnsDegradedWhenOpenRegisterUnavailable()
+
+    /**
+     * Test that the response always contains required fields: status, version, openRegisterAvailable.
+     *
+     * @spec openspec/changes/status-api/tasks.md#task-1
+     *
+     * @return void
+     */
+    public function testIndexResponseContainsRequiredFields(): void
+    {
+        $this->appManager->method('isInstalled')->willReturn(true);
+        $this->appManager->method('getAppVersion')->willReturn('1.0.0');
+
+        $result = $this->controller->index();
+        $data   = $result->getData();
+
+        self::assertArrayHasKey(key: 'status', array: $data);
+        self::assertArrayHasKey(key: 'version', array: $data);
+        self::assertArrayHasKey(key: 'openRegisterAvailable', array: $data);
+
+    }//end testIndexResponseContainsRequiredFields()
+}//end class


### PR DESCRIPTION
Closes #87

## Summary
Adds a public health check endpoint (`GET /api/health`) to Planix for use by load balancers and monitoring systems. The endpoint returns JSON with `status`, `version`, and `openRegisterAvailable` fields. It responds with HTTP 200 when OpenRegister is installed and HTTP 503 when it is unavailable, enabling automated health monitoring without authentication.

## Spec Reference
- Issue: #87
- Spec: `openspec/changes/status-api/design.md`

## Changes
- `lib/Controller/HealthController.php` — New controller providing the `GET /api/health` endpoint with `@PublicPage` and `@NoCSRFRequired` annotations for unauthenticated access
- `openspec/changes/status-api/design.md` — Spec copied into repo, status updated to `pr-created`
- `openspec/changes/status-api/tasks.md` — All acceptance criteria marked complete

## Test Coverage
- `tests/unit/Controller/HealthControllerTest.php` — 3 test methods: healthy response (200/ok), degraded response (503/degraded), and required response fields validation