### PR TITLE
feat: add GET /api/health endpoint

### DIFF
--- a/lib/Controller/HealthController.php
+++ b/lib/Controller/HealthController.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * Planix Health Controller
+ *
+ * Provides a public health check endpoint for load balancers and monitoring.
+ *
+ * @category Controller
+ * @package  OCA\Planix\Controller
+ *
+ * @author    Conduction Development Team <dev@conductio.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/status-api/tasks.md#task-1
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Planix\Controller;
+
+use OCA\Planix\AppInfo\Application;
+use OCA\Planix\Service\SettingsService;
+use OCP\App\IAppManager;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+
+/**
+ * Health check controller for Planix.
+ *
+ * Returns application health status as JSON for use by load balancers,
+ * monitoring tools, and Prometheus health probes (ADR-015).
+ *
+ * @spec openspec/changes/status-api/tasks.md#task-1
+ */
+class HealthController extends Controller
+{
+    /**
+     * Constructor for the HealthController.
+     *
+     * @param IRequest        $request         The request object
+     * @param SettingsService $settingsService The settings service
+     * @param IAppManager     $appManager      The app manager
+     *
+     * @spec openspec/changes/status-api/tasks.md#task-1
+     *
+     * @return void
+     */
+    public function __construct(
+        IRequest $request,
+        private SettingsService $settingsService,
+        private IAppManager $appManager,
+    ) {
+        parent::__construct(appName: Application::APP_ID, request: $request);
+    }//end __construct()
+
+    /**
+     * Return the health status of the Planix application.
+     *
+     * Reports whether the app is running and whether its OpenRegister
+     * dependency is available. Returns HTTP 200 when healthy, HTTP 503
+     * when OpenRegister is unavailable.
+     *
+     * @PublicPage
+     * @NoCSRFRequired
+     * @NoAdminRequired
+     *
+     * @spec openspec/changes/status-api/tasks.md#task-1
+     *
+     * @return JSONResponse
+     */
+    public function index(): JSONResponse
+    {
+        $openRegisterAvailable = $this->settingsService->isOpenRegisterAvailable();
+
+        if ($openRegisterAvailable === true) {
+            $status = 'ok';
+            $code   = Http::STATUS_OK;
+        } else {
+            $status = 'degraded';
+            $code   = Http::STATUS_SERVICE_UNAVAILABLE;
+        }
+
+        return new JSONResponse(
+            [
+                'status'                => $status,
+                'version'               => $this->appManager->getAppVersion(appId: Application::APP_ID),
+                'openRegisterAvailable' => $openRegisterAvailable,
+            ],
+            $code
+        );
+    }//end index()
+}//end class

--- a/openspec/changes/status-api/design.md
+++ b/openspec/changes/status-api/design.md
@@ -1,0 +1,9 @@
+# Status API
+
+**Status**: pr-created
+
+## Summary
+Add a health check endpoint to Planix per ADR-015 (Prometheus metrics & health).
+
+## Scope (1 task)
+- Backend: HealthController with GET /api/health returning JSON status

--- a/openspec/changes/status-api/tasks.md
+++ b/openspec/changes/status-api/tasks.md
@@ -1,0 +1,9 @@
+# Tasks — Status API
+
+## Task 1: Backend — Health check endpoint
+**spec_ref**: status-api/design.md
+**files_likely_affected**: lib/Controller/HealthController.php (new), appinfo/routes.php
+**acceptance_criteria**:
+- [x] `GET /api/health` returns JSON with `status`, `version`, and `openRegisterAvailable` fields
+- [x] Endpoint is public (no auth required) for load balancer use
+- [x] Returns HTTP 200 when healthy, 503 when OpenRegister unavailable

--- a/tests/unit/Controller/HealthControllerTest.php
+++ b/tests/unit/Controller/HealthControllerTest.php
@@ -1,0 +1,173 @@
+<?php
+
+/**
+ * Unit tests for HealthController.
+ *
+ * @category Test
+ * @package  OCA\Planix\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <dev@conductio.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/status-api/tasks.md#task-1
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Planix\Tests\Unit\Controller;
+
+use OCA\Planix\Controller\HealthController;
+use OCA\Planix\Service\SettingsService;
+use OCP\App\IAppManager;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for HealthController.
+ *
+ * @spec openspec/changes/status-api/tasks.md#task-1
+ */
+class HealthControllerTest extends TestCase
+{
+
+    /**
+     * The controller under test.
+     *
+     * @var HealthController
+     */
+    private HealthController $controller;
+
+    /**
+     * Mock IRequest.
+     *
+     * @var IRequest&MockObject
+     */
+    private IRequest&MockObject $request;
+
+    /**
+     * Mock SettingsService.
+     *
+     * @var SettingsService&MockObject
+     */
+    private SettingsService&MockObject $settingsService;
+
+    /**
+     * Mock IAppManager.
+     *
+     * @var IAppManager&MockObject
+     */
+    private IAppManager&MockObject $appManager;
+
+    /**
+     * Set up test fixtures.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->request         = $this->createMock(originalClassName: IRequest::class);
+        $this->settingsService = $this->createMock(originalClassName: SettingsService::class);
+        $this->appManager      = $this->createMock(originalClassName: IAppManager::class);
+
+        $this->controller = new HealthController(
+            request: $this->request,
+            settingsService: $this->settingsService,
+            appManager: $this->appManager,
+        );
+
+    }//end setUp()
+
+    /**
+     * Test that index() returns HTTP 200 with status "ok" when OpenRegister is available.
+     *
+     * @spec openspec/changes/status-api/tasks.md#task-1
+     *
+     * @return void
+     */
+    public function testIndexReturnsOkWhenOpenRegisterAvailable(): void
+    {
+        $this->settingsService->expects($this->once())
+            ->method('isOpenRegisterAvailable')
+            ->willReturn(true);
+
+        $this->appManager->expects($this->once())
+            ->method('getAppVersion')
+            ->willReturn('0.2.1');
+
+        $result = $this->controller->index();
+
+        self::assertInstanceOf(expected: JSONResponse::class, actual: $result);
+        self::assertSame(expected: Http::STATUS_OK, actual: $result->getStatus());
+
+        $data = $result->getData();
+        self::assertSame(expected: 'ok', actual: $data['status']);
+        self::assertSame(expected: '0.2.1', actual: $data['version']);
+        self::assertTrue(condition: $data['openRegisterAvailable']);
+
+    }//end testIndexReturnsOkWhenOpenRegisterAvailable()
+
+    /**
+     * Test that index() returns HTTP 503 with status "degraded" when OpenRegister is unavailable.
+     *
+     * @spec openspec/changes/status-api/tasks.md#task-1
+     *
+     * @return void
+     */
+    public function testIndexReturnsDegradedWhenOpenRegisterUnavailable(): void
+    {
+        $this->settingsService->expects($this->once())
+            ->method('isOpenRegisterAvailable')
+            ->willReturn(false);
+
+        $this->appManager->expects($this->once())
+            ->method('getAppVersion')
+            ->willReturn('0.2.1');
+
+        $result = $this->controller->index();
+
+        self::assertInstanceOf(expected: JSONResponse::class, actual: $result);
+        self::assertSame(expected: Http::STATUS_SERVICE_UNAVAILABLE, actual: $result->getStatus());
+
+        $data = $result->getData();
+        self::assertSame(expected: 'degraded', actual: $data['status']);
+        self::assertFalse(condition: $data['openRegisterAvailable']);
+
+    }//end testIndexReturnsDegradedWhenOpenRegisterUnavailable()
+
+    /**
+     * Test that index() response contains all required JSON fields.
+     *
+     * @spec openspec/changes/status-api/tasks.md#task-1
+     *
+     * @return void
+     */
+    public function testIndexResponseContainsRequiredFields(): void
+    {
+        $this->settingsService->expects($this->once())
+            ->method('isOpenRegisterAvailable')
+            ->willReturn(true);
+
+        $this->appManager->expects($this->once())
+            ->method('getAppVersion')
+            ->willReturn('1.0.0');
+
+        $result = $this->controller->index();
+        $data   = $result->getData();
+
+        self::assertArrayHasKey(key: 'status', array: $data);
+        self::assertArrayHasKey(key: 'version', array: $data);
+        self::assertArrayHasKey(key: 'openRegisterAvailable', array: $data);
+        self::assertSame(expected: '1.0.0', actual: $data['version']);
+
+    }//end testIndexResponseContainsRequiredFields()
+}//end class

--- a/tests/unit/Service/SettingsServiceTest.php
+++ b/tests/unit/Service/SettingsServiceTest.php
@@ -154,8 +154,9 @@ class SettingsServiceTest extends TestCase
         $this->appConfig->expects($this->exactly(count: 1))
             ->method('setValueString')
             ->willReturnCallback(
-                function (string $appId, string $key, string $value) use (&$stored): void {
+                function (string $appId, string $key, string $value) use (&$stored): bool {
                     $stored[$key] = $value;
+                    return true;
                 }
             );
 
@@ -194,8 +195,9 @@ class SettingsServiceTest extends TestCase
         $stored = [];
         $this->appConfig->method('setValueString')
             ->willReturnCallback(
-                function (string $appId, string $key, string $value) use (&$stored): void {
+                function (string $appId, string $key, string $value) use (&$stored): bool {
                     $stored[$key] = $value;
+                    return true;
                 }
             );
 


### PR DESCRIPTION
Closes #93

## Summary
Adds a public health check endpoint (`GET /api/health`) to Planix per ADR-015. The endpoint returns JSON with `status`, `version`, and `openRegisterAvailable` fields. It responds with HTTP 200 when healthy and HTTP 503 when OpenRegister is unavailable, making it suitable for load balancer and monitoring use.

## Spec Reference
- Issue: #93
- Spec: `openspec/changes/status-api/design.md`

## Changes
- `lib/Controller/HealthController.php` — New controller with public `index()` action returning health status JSON; uses `@PublicPage` annotation for unauthenticated access
- `openspec/changes/status-api/design.md` — OpenSpec design document (status: pr-created)
- `openspec/changes/status-api/tasks.md` — OpenSpec task list with all acceptance criteria checked

## Test Coverage
- `tests/unit/Controller/HealthControllerTest.php` — 3 unit tests: healthy response (200), degraded response (503), and required JSON fields validation