### PR TITLE
fix: white fill on app.svg so the header icon renders correctly

### DIFF
--- a/img/app.svg
+++ b/img/app.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#fff">
   <path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/>
 </svg>


### PR DESCRIPTION
## What

Sets `img/app.svg` to use `fill="#fff"` instead of `fill="currentColor"` (or a dark hex), matching stock Nextcloud apps.

## Why

The top navigation menu renders `app.svg` on a dark/themed background and expects a white monochrome icon. With `currentColor` the icon resolved to black, so it showed up as a black silhouette in the header.

## Scope

Single-file change to `img/app.svg`. `app-dark.svg` / `app-store.svg` unchanged.