### PR TITLE
fix: webpack publicPath uses /custom_apps/planix/js/ (closes #191)

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -65,10 +65,14 @@ webpackConfig.plugins = [
 // preventing the nextcloud-vue submodule's nested deps (Vue 3) from leaking in.
 webpackConfig.resolve.alias['@nextcloud/dialogs'] = path.resolve(__dirname, 'node_modules/@nextcloud/dialogs')
 
-// Override publicPath: app lives in apps-extra/planix/, not apps/planix/
+// Override publicPath so dynamic webpack chunks load from the standard
+// Nextcloud user-installed-app layout. The webpack-vue-config default of
+// /apps/{appName}/js/ is PHP-routed and returns 401 for static asset
+// requests; /apps-extra/ doesn't exist in the dev container. Every other
+// ConductionNL app is served from /custom_apps/<slug>/js/.
 webpackConfig.output = {
 	...webpackConfig.output,
-	publicPath: '/apps-extra/planix/js/',
+	publicPath: '/custom_apps/planix/js/',
 }
 
 module.exports = webpackConfig


### PR DESCRIPTION
The previous `publicPath` override pointed at `/apps-extra/planix/js/`, which doesn't exist in the standard Nextcloud `/custom_apps/` layout. Dynamic webpack chunks 404'd on every child route, surfacing as `ChunkLoadError` in the console and blank panes in the UI.

User-installed apps in the openregister dev container (and standard NC deployments) are served from `/custom_apps/<slug>/js/`. The default `publicPath` in `@nextcloud/webpack-vue-config` (`/apps/<slug>/js/`) is PHP-routed and 401s on static-asset requests, so we keep the override but point it at the working layout.

Fixes #191