### PR TITLE
chore(brand): align app-store hex to canonical cobalt #21468B

### DIFF
--- a/img/app-store.svg
+++ b/img/app-store.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
-  <polygon points="256,26 455.19,141 455.19,371 256,486 56.81,371 56.81,141" fill="#4376FC"/>
-  <g transform="translate(164, 164) scale(7.67)" fill="#ffffff">
+  <polygon points="256,26 455.19,141 455.19,371 256,486 56.81,371 56.81,141" fill="#21468B"/>
+  <g transform="translate(136, 136) scale(10)" fill="#ffffff">
     <path d="M16,5V18H21V5M4,18H9V5H4M10,18H15V5H10V18Z"/>
   </g>
 </svg>


### PR DESCRIPTION
Single-file change to `img/app-store.svg`: hex polygon fill updated from legacy `#4376FC` to canonical `#21468B` (`--c-blue-cobalt`). Part of the fleet sweep aligning the app icon to the brand cobalt — see [design-system colors.html](https://identity.conduction.nl/preview/colors.html) for the rationale. No code or behavior changes.