### PR TITLE
chore(brand): preset 2.10 + auto-derived hero + smaller app-icon glyph

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -8,7 +8,7 @@
       "name": "planix-docs",
       "version": "0.0.0",
       "dependencies": {
-        "@conduction/docusaurus-preset": "^2.6.1",
+        "@conduction/docusaurus-preset": "^2.10.0",
         "@docusaurus/core": "^3.7.0",
         "@docusaurus/preset-classic": "^3.7.0",
         "@docusaurus/theme-mermaid": "^3.7.0",
@@ -2012,9 +2012,9 @@
       }
     },
     "node_modules/@conduction/docusaurus-preset": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-2.6.1.tgz",
-      "integrity": "sha512-hOkS2XAj3p1wfaZWjvIqKzwC5cbTSLUPm+DJxUp7TePbnU37kaHGegjLjfVOnQ312G8an+0M5VWIhmg/YhRVyA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-2.10.0.tgz",
+      "integrity": "sha512-YLYjKv4OmlP/XzXh9kS0/4IEV9zXldE9h1nhzb3GAVTblt+ZkYRnzvthkqm0PMD1P8Ou4tbBvTt1VgjlsjYMKg==",
       "license": "EUPL-1.2",
       "peerDependencies": {
         "@docusaurus/core": "^3.0.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,7 +15,7 @@
     "ci": "npm ci --legacy-peer-deps && npm run build"
   },
   "dependencies": {
-    "@conduction/docusaurus-preset": "^2.6.1",
+    "@conduction/docusaurus-preset": "^2.10.0",
     "@docusaurus/core": "^3.7.0",
     "@docusaurus/preset-classic": "^3.7.0",
     "@docusaurus/theme-mermaid": "^3.7.0",

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -397,8 +397,7 @@ export default function Home() {
         <DetailHero
           background="cobalt"
           appId="planix"
-          status={{ label: 'Beta', color: 'var(--c-orange-knvb)' }}
-          version="v0.2"
+          /* status + version dropped — preset 2.10+ auto-derives from appinfo/info.xml */
           locales="EN"
           title="Planix"
           tagline={TAGLINE}

--- a/docs/static/img/logo.svg
+++ b/docs/static/img/logo.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
   <polygon points="256,26 455.19,141 455.19,371 256,486 56.81,371 56.81,141" fill="#4376FC"/>
-  <g transform="translate(136, 136) scale(10)" fill="#ffffff">
+  <g transform="translate(164, 164) scale(7.67)" fill="#ffffff">
     <path d="M16,5V18H21V5M4,18H9V5H4M10,18H15V5H10V18Z"/>
   </g>
 </svg>

--- a/img/app-store.svg
+++ b/img/app-store.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
   <polygon points="256,26 455.19,141 455.19,371 256,486 56.81,371 56.81,141" fill="#4376FC"/>
-  <g transform="translate(136, 136) scale(10)" fill="#ffffff">
+  <g transform="translate(164, 164) scale(7.67)" fill="#ffffff">
     <path d="M16,5V18H21V5M4,18H9V5H4M10,18H15V5H10V18Z"/>
   </g>
 </svg>


### PR DESCRIPTION
Aligns this app with the design-system 2.10.0 release: preset bumped, hard-coded `<DetailHero/>` `status`/`version` props dropped (the new preset auto-derives from `appinfo/info.xml` + SemVer), inner glyph in `img/app-store.svg` shrunk to ~40% of the hex height. No code or behaviour changes beyond the brand chrome.