### PR TITLE
fix(tests): IAppConfig::setValueString mock callbacks must return bool

### DIFF
--- a/tests/unit/Service/SettingsServiceTest.php
+++ b/tests/unit/Service/SettingsServiceTest.php
@@ -154,8 +154,9 @@ class SettingsServiceTest extends TestCase
         $this->appConfig->expects($this->exactly(count: 1))
             ->method('setValueString')
             ->willReturnCallback(
-                function (string $appId, string $key, string $value) use (&$stored): void {
+                function (string $appId, string $key, string $value) use (&$stored): bool {
                     $stored[$key] = $value;
+                    return true;
                 }
             );
 
@@ -194,8 +195,9 @@ class SettingsServiceTest extends TestCase
         $stored = [];
         $this->appConfig->method('setValueString')
             ->willReturnCallback(
-                function (string $appId, string $key, string $value) use (&$stored): void {
+                function (string $appId, string $key, string $value) use (&$stored): bool {
                     $stored[$key] = $value;
+                    return true;
                 }
             );
 


### PR DESCRIPTION
Fixes all PHPUnit failures across the PHP 8.3/8.4 x NC stable31/32/33 matrix.

## Root cause
`IAppConfig::setValueString()` returns `bool` in NC stable31+. The two test mock callbacks in `SettingsServiceTest` declared `void` and returned null, causing:

```
TypeError: MockObject_IAppConfig_xxx::setValueString(): Return value must be of type bool, null returned
```

## Fix
Change both `willReturnCallback` callbacks to declare `: bool` return and `return true;` on success.

## Impact
Unblocks 7 open planix PRs that were all red on the same upstream PHPUnit failure (#197, #198, #178, #177, #182, #184, #176).