### PR TITLE
fix(brand): revert app-store.svg cobalt to canonical #4376FC

### DIFF
--- a/img/app-store.svg
+++ b/img/app-store.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
-  <polygon points="256,26 455.19,141 455.19,371 256,486 56.81,371 56.81,141" fill="#21468B"/>
+  <polygon points="256,26 455.19,141 455.19,371 256,486 56.81,371 56.81,141" fill="#4376FC"/>
   <g transform="translate(136, 136) scale(10)" fill="#ffffff">
     <path d="M16,5V18H21V5M4,18H9V5H4M10,18H15V5H10V18Z"/>
   </g>


### PR DESCRIPTION
PR #197 (planix) / #236 (softwarecatalog) was merged with cobalt hex `#21468B` which is NOT the canonical Conduction Cobalt — per `reference_conduction-brand-hex.md` the canonical is `#4376FC`. All other Conduction apps in the fleet (mydash/larpingapp/decidesk/procest/openbuilt/scholiq/deskdesk/pipelinq) use #4376FC. Reverting to the canonical hex.