### PR TITLE
fix(brand): re-apply canonical #21468B cobalt (reverting my earlier revert)

### DIFF
--- a/img/app-store.svg
+++ b/img/app-store.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
-  <polygon points="256,26 455.19,141 455.19,371 256,486 56.81,371 56.81,141" fill="#4376FC"/>
+  <polygon points="256,26 455.19,141 455.19,371 256,486 56.81,371 56.81,141" fill="#21468B"/>
   <g transform="translate(136, 136) scale(10)" fill="#ffffff">
     <path d="M16,5V18H21V5M4,18H9V5H4M10,18H15V5H10V18Z"/>
   </g>


### PR DESCRIPTION
I incorrectly reverted PR #197/#236's #21468B cobalt to #4376FC, thinking #4376FC was canonical. The detailed memory at reference_conduction-brand-hex.md states canonical IS #21468B (Dutch flag blue, --c-blue-cobalt); #4376FC is the LEGACY value retired 2026-05-13. Re-applying #21468B.