### PR TITLE
fix(docs): descriptive homepage title (#80)

### DIFF
--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -390,7 +390,7 @@ const WIDGETS = [
 export default function Home() {
   return (
     <Layout
-      title="Planix"
+      title="Planix, kanban project management for Nextcloud teams"
       description="Planix runs the board — projects, tasks, Kanban columns with WIP limits, a real backlog, and per-task time entries — a focused workflow tool for dev and IT teams, built into Nextcloud on top of OpenRegister."
     >
       <main className="marketing-page">


### PR DESCRIPTION
Part of ConductionNL/.github#75 SEO epic and closes ConductionNL/.github#80. Single-prop edit.