### PR TITLE
sync: development → documentation (meta descriptions #81)

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+description: Get started with Planix, kanban project management for Nextcloud teams. Boards, lanes, tickets, and CI signal in your collaboration stack.
 ---
 
 # Planix

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -391,7 +391,7 @@ export default function Home() {
   return (
     <Layout
       title="Planix, kanban project management for Nextcloud teams"
-      description="Planix runs the board — projects, tasks, Kanban columns with WIP limits, a real backlog, and per-task time entries — a focused workflow tool for dev and IT teams, built into Nextcloud on top of OpenRegister."
+      description="Kanban project management for Nextcloud dev and IT teams. Projects, tasks, WIP-limited columns, a real backlog, and per-task time tracking."
     >
       <main className="marketing-page">
         <DetailHero


### PR DESCRIPTION
Sync development → documentation so the meta-description deploy fires.