### PR TITLE
chore(docs): bump @conduction/docusaurus-preset to 3.10.0 (#79)

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -8,7 +8,7 @@
       "name": "planix-docs",
       "version": "0.0.0",
       "dependencies": {
-        "@conduction/docusaurus-preset": "^2.10.0",
+        "@conduction/docusaurus-preset": "^3.10.0",
         "@docusaurus/core": "^3.7.0",
         "@docusaurus/preset-classic": "^3.7.0",
         "@docusaurus/theme-mermaid": "^3.7.0",
@@ -2012,10 +2012,13 @@
       }
     },
     "node_modules/@conduction/docusaurus-preset": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-2.10.0.tgz",
-      "integrity": "sha512-YLYjKv4OmlP/XzXh9kS0/4IEV9zXldE9h1nhzb3GAVTblt+ZkYRnzvthkqm0PMD1P8Ou4tbBvTt1VgjlsjYMKg==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-3.10.0.tgz",
+      "integrity": "sha512-wFjmNtjON+ks0Aqzql1wGy6TCQPLsJTzMY1C8uwNnj+jTpGVGZ3QVqd6I/0oVDYhdgAjgdrijRhyN3L2Er4U7Q==",
       "license": "EUPL-1.2",
+      "bin": {
+        "validate-ai-baseline": "bin/validate-ai-baseline.mjs"
+      },
       "peerDependencies": {
         "@docusaurus/core": "^3.0.0",
         "@docusaurus/preset-classic": "^3.0.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,7 +15,7 @@
     "ci": "npm ci --legacy-peer-deps && npm run build"
   },
   "dependencies": {
-    "@conduction/docusaurus-preset": "^2.10.0",
+    "@conduction/docusaurus-preset": "^3.10.0",
     "@docusaurus/core": "^3.7.0",
     "@docusaurus/preset-classic": "^3.7.0",
     "@docusaurus/theme-mermaid": "^3.7.0",


### PR DESCRIPTION
Lockfile-only bump for ConductionNL/.github#79. Part of SEO epic #75.

Note: also bumps docs/package.json range from `^2.10.0` → `^3.10.0` so the lockfile resolves the major-version-3 preset.