### PR TITLE
fix(settings): remove cross-app raw SQL on openregister_registers (ADR-001)

### DIFF
--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -231,17 +231,12 @@ class SettingsService
 
             if (empty($result) === false) {
                 $this->logger->info('Planix: register configuration imported successfully');
-                $this->ensureRegisterPublicAccess();
                 return [
                     'success' => true,
                     'message' => 'Configuration imported successfully.',
                     'version' => ($result['version'] ?? 'unknown'),
                 ];
             }
-
-            // ImportFromApp may return empty even when the register already existed
-            // and was updated. Apply the public-access patch unconditionally.
-            $this->ensureRegisterPublicAccess();
 
             return [
                 'success' => false,
@@ -259,35 +254,4 @@ class SettingsService
         }//end try
 
     }//end loadConfiguration()
-
-    /**
-     * Directly update the planix register's public access flags in the DB.
-     *
-     * Called after importFromApp to ensure publicWrite/publicRead are set to 0
-     * (private) even if OpenRegister's ConfigurationService did not update an
-     * existing record. Keeps the register accessible only to authenticated
-     * Nextcloud users; never grants anonymous access.
-     * Fails silently — any exception is logged as a warning only.
-     *
-     * @return void
-     */
-    private function ensureRegisterPublicAccess(): void
-    {
-        try {
-            $db = $this->container->get(\OCP\IDBConnection::class);
-            $qb = $db->getQueryBuilder();
-            $qb->update('openregister_registers')
-                ->set('public_write', $qb->createNamedParameter(0, \OCP\DB\QueryBuilder\IQueryBuilder::PARAM_INT))
-                ->set('public_read', $qb->createNamedParameter(0, \OCP\DB\QueryBuilder\IQueryBuilder::PARAM_INT))
-                ->where($qb->expr()->eq('slug', $qb->createNamedParameter('planix')));
-            $qb->executeStatement();
-            $this->logger->info('Planix: register publicWrite/publicRead set to private (0) in DB');
-        } catch (\Throwable $e) {
-            $this->logger->warning(
-                'Planix: could not directly update register public access in DB',
-                ['error' => $e->getMessage()]
-            );
-        }//end try
-
-    }//end ensureRegisterPublicAccess()
 }//end class

--- a/lib/Settings/planix_register.json
+++ b/lib/Settings/planix_register.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Planix Register",
     "description": "Register containing all schemas for the Planix application.",
-    "version": "0.2.1"
+    "version": "0.2.2"
   },
   "x-openregister": {
     "type": "application",
@@ -21,9 +21,7 @@
         "version": "0.2.0",
         "schemas": ["task", "project", "column", "timeEntry", "label"],
         "tablePrefix": "planix",
-        "folder": "planix",
-        "publicWrite": true,
-        "publicRead": true
+        "folder": "planix"
       }
     },
     "schemas": {


### PR DESCRIPTION
## Summary
Removes `SettingsService::ensureRegisterPublicAccess()`, which issued a raw `UPDATE openregister_registers SET public_write=0, public_read=0` from Planix against OpenRegister's own table — a direct ADR-001 violation (apps consume OR via its public API; they don't reach into another app's DB).

## What was the bug doing?
Investigation revealed the raw SQL was **already a permanent silent no-op**:

- OpenRegister has **no** `public_read` / `public_write` columns. They aren't declared in any migration; there are zero references in the OR codebase (`lib/`, `appinfo/`). The Register entity (`openregister/lib/Db/Register.php`) has no matching properties.
- Any "column does not exist" error was swallowed by `catch (\Throwable)` and only logged as a warning, so nobody noticed.
- The matching `publicWrite: true`/`publicRead: true` in `planix_register.json` were also ignored by `Entity::hydrate()` for the same reason — Register has no setter for them.

OpenRegister's actual per-register access mechanism is the `authorization` array (RBAC groups), not a boolean toggle.

## Before / After
**Before** (raw SQL, ADR-001 violation, also a silent no-op):
```php
$db = $this->container->get(\OCP\IDBConnection::class);
$qb->update('openregister_registers')
   ->set('public_write', ...)
   ->set('public_read', ...)
   ->where(...);
```

**After**: method deleted, both callers removed. Stale `publicWrite`/`publicRead` removed from the register payload. `info.version` bumped to `0.2.2` so existing installs re-import the cleaned-up payload.

## Safety
Pure deletion. Post-install access posture is unchanged because the previous code was always failing silently. If Planix later needs an enforceable anonymous-read toggle, the right path is a feature request on OpenRegister, not bypassing the abstraction differently.

## Composer check
`composer check`: ALL CHECKS PASSED (PHPCS 0 errors, Psalm clean, lint clean). PHPCS warnings are pre-existing `@spec` tag gaps already catalogued in `openspec/coverage-report.md` Bucket 4 — addressed separately via `/opsx-annotate`.

Refs #236