### PR TITLE
retrofit: reverse-spec projects/Backlog (1 REQ / 1 method)

### DIFF
--- a/openspec/changes/archive/retrofit-2026-05-24-reverse-spec-projects-backlog/design.md
+++ b/openspec/changes/archive/retrofit-2026-05-24-reverse-spec-projects-backlog/design.md
@@ -1,0 +1,82 @@
+# Design — Retrofit Project Backlog Route
+
+**Retrofit change.** Tasks describe retroactive annotation, not new implementation work.
+
+## Context
+
+Phase 0/1/2 of the planix retrofit pipeline produced:
+- `feature/i18n-complete-translations` baseline (closed prior PRs)
+- planix#237 — direct-SQL violation fix in `SettingsService::ensureRegisterPublicAccess`
+- planix#238 — Bucket 1 annotations across 48 methods / 13 REQs / 4 capabilities
+
+The coverage scan flagged 2 Bucket 2a clusters (existing code, no REQ):
+
+1. `register-schemas` → `lib/Settings/planix_register.json` — **skipped**; the
+   scanner enumerates `.php`/`.vue`/`.js`/`.ts` files only, JSON manifests are
+   informational. The coverage report's own note states this entry is
+   "informational only" and the schema declaration is already covered by the
+   Bucket 1 annotation on `lib/Listener/DeepLinkRegistrationListener.php::handle`
+   (REQ-All-5-schemas-defined).
+
+2. `projects` → `src/views/ProjectBacklog.vue` — addressed by this change.
+   The Vue view, its router entry, and its mounted-hook side effect ship on
+   `development` but no REQ in `openspec/specs/projects.md` mentions a backlog
+   route.
+
+## Why --extend, not --cluster
+
+`projects` is an existing capability with 12 REQs. The Backlog route is part
+of the project-detail surface (sibling to ProjectBoard) — it belongs in the
+same spec. Minting a new `project-backlog` capability would imply a
+larger surface that does not exist yet.
+
+## Why one REQ, not more
+
+The view does exactly three observable things:
+1. Renders a breadcrumb chain back to the project board
+2. Hydrates the projects store on direct deep-link
+3. Shows a placeholder NcEmptyContent
+
+These all express a single user-visible behavior — "the route exists as a
+navigable shell" — and naturally compose into one REQ with three scenarios.
+Splitting them into 2-3 REQs would inflate the spec without adding review
+surface; collapsing them into one REQ with one scenario would lose the
+direct-deep-link guarantee (which is the most likely thing to silently
+regress).
+
+## REQ ID convention
+
+Slug-style (`REQ-Project-Backlog-Route`) to match planix's existing flat-file
+spec convention. The SKILL.md prefers numbered IDs, but Phase 2 (#238) used
+slug IDs across all 13 annotations to stay consistent with the existing
+`projects.md` style. Mixing numbered and slug IDs inside one capability would
+break the convention without buying anything; fleet consistency wins here.
+
+## Frontmatter
+
+Uses block YAML `retrofit_extensions:` to flag the cohort for Specter sync.
+Single entry, but block-form scales as future retrofit deltas accumulate.
+
+## Annotation scope
+
+Two `@spec` tags on `ProjectBacklog.vue`:
+- One in the file-level docblock (top of `<script>`)
+- One on the `mounted()` hook (the only method with observable side effects)
+
+`projectTitle` is a one-liner derived computed; annotating it adds noise
+without value. Same for the `projectsStore` getter.
+
+## What this change does NOT do
+
+- No code-behavior changes — placeholder copy stays exactly as-is.
+- No router or store changes.
+- Does not promote the Backlog placeholder to a real backlog view (that
+  belongs in a future `tasks` change after `tasks#REQ-Task-CRUD` lands).
+- Does not retire any Bucket 3b REQ — leaves the planned-but-not-built REQs
+  visible in the coverage report.
+
+## Risk
+
+Minimal. Spec-only change + 2 annotation lines on a placeholder Vue file.
+The next coverage scan should match the Backlog view against the new REQ and
+promote it from Bucket 2a to Bucket 1 (annotated).

--- a/openspec/changes/archive/retrofit-2026-05-24-reverse-spec-projects-backlog/proposal.md
+++ b/openspec/changes/archive/retrofit-2026-05-24-reverse-spec-projects-backlog/proposal.md
@@ -1,0 +1,35 @@
+# Retrofit — projects (Backlog placeholder route)
+
+Describes observed behavior of 1 Vue component under the `projects` capability as 1 new REQ. Code already exists — this change retroactively specifies it.
+
+## Affected code units
+- src/views/ProjectBacklog.vue — `/projects/:id/backlog` route placeholder
+
+## Approach
+- Read the component and describe observed inputs (route param, projects store),
+  outputs (rendered breadcrumb + placeholder), preconditions (project must
+  resolve via the store), and failure modes (project fetch failure surfaces via
+  the store, not the view itself).
+- Draft 1 REQ that matches the observed behavior — a navigable shell rendering
+  a placeholder, not a working backlog. The placement of the route +
+  breadcrumb is the user-visible behavior worth specifying; the fact that the
+  list itself is a stub is captured as a deliberate note so a future
+  task-management REQ can replace this without ambiguity.
+- The Notes section flags that the route is a deliberate scaffold awaiting
+  tasks#REQ-Task-CRUD (Bucket 3b in the coverage report); the placeholder
+  copy must stay aligned with the unimplemented task feature until that
+  REQ lands.
+
+## Why this is Bucket 2a
+The `projects` capability spec exists (openspec/specs/projects.md) but does
+not mention the Backlog route — yet the route, view, and breadcrumb are wired
+in `src/router/index.js`. Falls into "existing capability, no REQ" — the
+coverage scan flagged it for reverse-spec with `--extend projects`.
+
+The other Bucket 2a entry (`register-schemas` → `lib/Settings/planix_register.json`)
+is skipped per the coverage report's own note: the scanner enumerates
+`.php`/`.vue`/`.js`/`.ts` files but not JSON, and the schema manifest is the
+canonical implementation of REQs already covered by Bucket 1 annotations
+(`REQ-All-5-schemas-defined`).
+
+Source: openspec/coverage-report.md generated 2026-05-24. See [retrofit playbook](../../../../.github/docs/claude/retrofit.md).

--- a/openspec/changes/archive/retrofit-2026-05-24-reverse-spec-projects-backlog/specs/projects/spec.md
+++ b/openspec/changes/archive/retrofit-2026-05-24-reverse-spec-projects-backlog/specs/projects/spec.md
@@ -1,0 +1,52 @@
+---
+retrofit_extensions:
+  - REQ-Project-Backlog-Route
+---
+
+# Projects — Retrofit Spec Delta
+
+This delta adds 1 new REQ to the `projects` capability describing the existing
+Backlog placeholder route. The behavior already ships on `development`; this
+spec retroactively captures it so the route stops being orphaned (no REQ →
+unannotatable) until tasks#REQ-Task-CRUD lands and replaces the placeholder.
+
+## Implementation Requirements
+
+### Requirement: Project Backlog Route [MVP]
+
+The system MUST provide a navigable Backlog route per project that renders
+inside the project context (breadcrumb back to project board) and shows a
+placeholder until task management ships.
+
+#### Scenario: Navigate to backlog route
+- GIVEN the user is authenticated and a project exists with id `:id`
+- WHEN the user navigates to `/projects/:id/backlog`
+- THEN the system MUST render the `ProjectBacklog` view
+- AND the breadcrumb MUST show `Projects > {projectTitle} > Backlog`
+- AND each breadcrumb segment except the current one MUST be a clickable
+  `NcButton` routing back to the parent view
+
+#### Scenario: Hydrate project context on direct deep link
+- GIVEN the user opens `/projects/:id/backlog` as the first navigation
+  (e.g. via a bookmark) and the projects store has no `activeProject`
+- WHEN the `ProjectBacklog` view mounts
+- THEN the view MUST call `projectsStore.fetchProject(:id)` so the
+  breadcrumb title resolves to the project title rather than the raw UUID
+
+#### Scenario: Placeholder until task management is implemented
+- GIVEN the `ProjectBacklog` view has rendered
+- WHEN there is no task-management implementation yet
+- THEN the view MUST show an `NcEmptyContent` with name "Backlog view coming
+  soon" and description "Task management will be available in a future update."
+- AND the placeholder MUST use the `FormatListBulleted` MDI icon so the
+  feature intent is recognisable
+
+#### Notes
+- The placeholder copy is deliberate. It MUST stay aligned with the
+  unimplemented `tasks#REQ-Task-CRUD` and `kanban-board#REQ-Kanban-Board-View`
+  REQs (currently Bucket 3b — planned, never started). When task-management
+  lands, this REQ should either be retired in favour of a real backlog REQ
+  or rewritten to describe the populated list view.
+- The view does not own loading or error states beyond what the projects
+  store provides — those are covered by `projects#REQ-Loading-and-Error-States`
+  (also Bucket 3b at the time of retrofit).

--- a/openspec/changes/archive/retrofit-2026-05-24-reverse-spec-projects-backlog/tasks.md
+++ b/openspec/changes/archive/retrofit-2026-05-24-reverse-spec-projects-backlog/tasks.md
@@ -1,0 +1,3 @@
+# Tasks
+
+- [x] task-1: projects#REQ-Project-Backlog-Route — Project Backlog Route (retroactive annotation)

--- a/openspec/specs/projects.md
+++ b/openspec/specs/projects.md
@@ -1,3 +1,8 @@
+---
+retrofit_extensions:
+  - REQ-Project-Backlog-Route
+---
+
 # Projects Specification
 
 **Status**: done
@@ -289,6 +294,36 @@ The OpenRegister gate check MUST occur in the App root component (`App.vue`) bef
   - Title: "OpenRegister is required"
   - Description: "Planix requires OpenRegister to store its data."
   - Action button (admin only): "Install OpenRegister" linking to the Nextcloud App Store
+
+---
+
+### Requirement: Project Backlog Route [MVP]
+
+> Added by the `retrofit-2026-05-24-reverse-spec-projects-backlog` change — retroactively specifies the existing `/projects/:id/backlog` placeholder route.
+
+The system MUST provide a navigable Backlog route per project that renders inside the project context (breadcrumb back to project board) and shows a placeholder until task management ships.
+
+#### Scenario: Navigate to backlog route
+- GIVEN the user is authenticated and a project exists with id `:id`
+- WHEN the user navigates to `/projects/:id/backlog`
+- THEN the system MUST render the `ProjectBacklog` view
+- AND the breadcrumb MUST show `Projects > {projectTitle} > Backlog`
+- AND each breadcrumb segment except the current one MUST be a clickable `NcButton` routing back to the parent view
+
+#### Scenario: Hydrate project context on direct deep link
+- GIVEN the user opens `/projects/:id/backlog` as the first navigation (e.g. via a bookmark) and the projects store has no `activeProject`
+- WHEN the `ProjectBacklog` view mounts
+- THEN the view MUST call `projectsStore.fetchProject(:id)` so the breadcrumb title resolves to the project title rather than the raw UUID
+
+#### Scenario: Placeholder until task management is implemented
+- GIVEN the `ProjectBacklog` view has rendered
+- WHEN there is no task-management implementation yet
+- THEN the view MUST show an `NcEmptyContent` with name "Backlog view coming soon" and description "Task management will be available in a future update."
+- AND the placeholder MUST use the `FormatListBulleted` MDI icon so the feature intent is recognisable
+
+#### Notes
+- The placeholder copy is deliberate. It MUST stay aligned with the unimplemented `tasks#REQ-Task-CRUD` and `kanban-board#REQ-Kanban-Board-View` REQs (currently Bucket 3b — planned, never started). When task management lands, this REQ should either be retired in favour of a real backlog REQ or rewritten to describe the populated list view.
+- The view does not own loading or error states beyond what the projects store provides — those are covered by `Requirement: Loading and Error States` above.
 
 ---
 

--- a/src/views/ProjectBacklog.vue
+++ b/src/views/ProjectBacklog.vue
@@ -32,6 +32,17 @@
 </template>
 
 <script>
+/**
+ * ProjectBacklog view.
+ *
+ * Renders the `/projects/:id/backlog` route as a navigable shell — breadcrumb
+ * back to the project board plus a placeholder NcEmptyContent. Hydrates the
+ * projects store on direct deep link so the breadcrumb resolves the project
+ * title rather than echoing the raw UUID. Stays a placeholder until
+ * tasks#REQ-Task-CRUD lands.
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-reverse-spec-projects-backlog/tasks.md#task-1
+ */
 import { NcButton, NcEmptyContent } from '@nextcloud/vue'
 import FormatListBulleted from 'vue-material-design-icons/FormatListBulleted.vue'
 import { useProjectsStore } from '../store/projects.js'
@@ -54,6 +65,12 @@ export default {
 		},
 	},
 
+	/**
+	 * Hydrate the projects store on direct deep link so the breadcrumb
+	 * title resolves to the project title rather than the raw UUID.
+	 *
+	 * @spec openspec/changes/retrofit-2026-05-24-reverse-spec-projects-backlog/tasks.md#task-1
+	 */
 	async mounted() {
 		if (!this.projectsStore.activeProject || this.projectsStore.activeProject.id !== this.$route.params.id) {
 			await this.projectsStore.fetchProject(this.$route.params.id)


### PR DESCRIPTION
## Retrofit — Reverse-Spec

Describes observed behavior of 1 method under `projects` (the `ProjectBacklog` view + its `mounted()` hook) as 1 new REQ.

Ghost change: `retrofit-2026-05-24-reverse-spec-projects-backlog` (archived).

### What this PR does

- Drafts 1 REQ (`Project Backlog Route`) under `projects` capability — `retrofit_extensions: [REQ-Project-Backlog-Route]` on `openspec/specs/projects.md`
- Creates `tasks.md` with one task per REQ
- Annotates `src/views/ProjectBacklog.vue` with `@spec` tags on the file docblock + `mounted()` hook
- Archives the change (merges spec delta into `openspec/specs/projects.md` under Implementation Requirements)

### What this PR does NOT do

- No code behavior changes — placeholder copy stays exactly as-is
- Does not promote the Backlog placeholder to a real backlog view (waits on `tasks#REQ-Task-CRUD`, Bucket 3b)
- Does not retire any planned-but-not-built REQ

### Bucket 2a — the other entry was skipped

The coverage report's other 2a entry (`register-schemas` → `lib/Settings/planix_register.json`) is explicitly informational per the report's own notes — the scanner only enumerates `.php`/`.vue`/`.js`/`.ts` files, and the schema declaration is already covered by the Bucket 1 annotation on `DeepLinkRegistrationListener::handle` (REQ-All-5-schemas-defined). No code unit to reverse-spec.

### Review focus

- REQ language describes what the view *actually does* (navigable shell + placeholder), not what a real backlog would do
- Scenarios are testable in isolation: route exists, deep-link hydrates, placeholder message renders
- Notes flag that the placeholder copy must stay aligned with the unimplemented tasks-CRUD REQs

Source: `openspec/coverage-report.json` generated 2026-05-24 | Cluster: `projects (Backlog)`

Refs ConductionNL/planix#236