### PR TITLE
retrofit: planix spec-coverage to zero (49 annotated / 3 reverse-spec REQs)

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,4 @@
 # Retrofit annotation commit (opsx-annotate, 2026-05-24)
 4845d1c3b3b712a2d696aaf3d59d8a75d9d887a8
+# Retrofit coverage-to-zero annotation commit (2026-05-25)
+12915a2

--- a/lib/Controller/DashboardController.php
+++ b/lib/Controller/DashboardController.php
@@ -50,6 +50,8 @@ class DashboardController extends Controller
      * @NoCSRFRequired
      *
      * @return TemplateResponse
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-app-shell-and-data-store/tasks.md#task-1
      */
     public function page(): TemplateResponse
     {
@@ -63,6 +65,8 @@ class DashboardController extends Controller
      * @NoCSRFRequired
      *
      * @return TemplateResponse
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-app-shell-and-data-store/tasks.md#task-1
      */
     public function catchAll(): TemplateResponse
     {

--- a/openspec/changes/archive/retrofit-2026-05-25-app-shell-and-data-store/design.md
+++ b/openspec/changes/archive/retrofit-2026-05-25-app-shell-and-data-store/design.md
@@ -1,0 +1,67 @@
+# Design — Retrofit App Shell & Data Store
+
+**Retrofit change.** Tasks describe retroactive annotation, not new implementation work.
+
+## Context
+
+Phase 3 of the planix retrofit pipeline (coverage-to-zero) annotated 49 of 55
+frontend + 2 backend methods via Bucket 1 `@spec` tags (mapping to the archived
+`retrofit-2026-05-24-annotate-planix` change) and `@spec exclude` markers for
+framework glue. Six methods described real behavior with no owning REQ:
+
+- `lib/Controller/DashboardController.php::page` / `::catchAll` — serve the SPA
+  shell. No spec mentioned the SPA-serving controller; `dashboard-my-work.md`
+  covers the KPI dashboard feature, not the app-shell controller.
+- `src/store/modules/object.js::configure` / `::registerObjectType` /
+  `::fetchObjects` — the generic OpenRegister object store module. No REQ owned it.
+- `src/store/store.js::initializeStores` — boot-time wiring of the object stores.
+
+## Why --cluster, not --extend
+
+There is no existing capability for the application shell or the generic data
+store. `projects.md`, `dashboard-my-work.md`, and `admin-user-settings.md` are
+all feature specs; none own the foundational shell/store layer. Extending any of
+them would mislocate infrastructure behavior inside a feature spec. A new
+`app-shell-and-data-store` capability is the honest home.
+
+## Why three REQs
+
+The six methods split cleanly into three observable behaviors:
+
+1. **SPA Page Serving** — backend controller renders the SPA for the root page
+   and history-mode deep links (`page` + `catchAll`).
+2. **Generic Object Store** — configurable, type-registered OpenRegister fetch
+   plumbing (`configure` + `registerObjectType` + `fetchObjects`).
+3. **Store Bootstrap** — the boot routine that wires both stores and primes
+   settings before render (`initializeStores`).
+
+Collapsing these would lose distinct guarantees (e.g. the deep-link delegation,
+the unregistered-type guard); splitting further would inflate the spec.
+
+## REQ ID convention
+
+Slug-style (`REQ-SPA-Page-Serving`) to match planix's existing flat-file spec
+convention used across the prior Bucket 1 annotations and the projects-backlog
+retrofit.
+
+## Frontmatter
+
+Uses `retrofit: true` (new capability) to flag the cohort for Specter sync.
+
+## Annotation scope
+
+`@spec` tags land on: the two `DashboardController` methods (task-1), the three
+`object.js` actions (task-2), and `initializeStores` (task-3). The PHP class
+docblock keeps its existing license header; per-method `@spec` lines are added
+inside each method's own docblock.
+
+## What this change does NOT do
+
+- No code-behavior changes — annotations only.
+- Does not silently fix observed behavior. Note flagged: `fetchObjects` swallows
+  network/parse errors and returns `[]` rather than surfacing them — this is the
+  observed behavior and is specified as-is.
+
+## Risk
+
+Minimal. Spec-only new capability + six annotation docblocks.

--- a/openspec/changes/archive/retrofit-2026-05-25-app-shell-and-data-store/proposal.md
+++ b/openspec/changes/archive/retrofit-2026-05-25-app-shell-and-data-store/proposal.md
@@ -1,0 +1,26 @@
+# Retrofit — app-shell-and-data-store
+
+Describes observed behavior of 6 methods under `app-shell-and-data-store` as 3 new REQs. Code already exists — this change retroactively specifies it.
+
+## Affected code units
+
+- `lib/Controller/DashboardController.php::page()` — serves the SPA index template
+- `lib/Controller/DashboardController.php::catchAll()` — serves the SPA for Vue history-mode deep links
+- `src/store/modules/object.js::configure()` — sets the OpenRegister base URLs on the generic object store
+- `src/store/modules/object.js::registerObjectType()` — registers a schema/register pair under a type key
+- `src/store/modules/object.js::fetchObjects()` — fetches a typed object collection from OpenRegister
+- `src/store/store.js::initializeStores()` — boot-time wiring of both object stores plus settings fetch
+
+## Approach
+
+- For each method: describe observed inputs, outputs, pre/postconditions, failure modes.
+- Draft REQs that match the shipped behavior (not aspirational).
+- Group the behavior into one capability: the foundational app shell that serves the
+  single-page application and the generic OpenRegister data store that the shell boots.
+
+Three REQs:
+- **REQ-SPA-Page-Serving** — the backend controller that renders the SPA shell for the root page and for Vue history-mode deep links.
+- **REQ-Generic-Object-Store** — the configurable, type-registered OpenRegister object store module that fetches typed collections.
+- **REQ-Store-Bootstrap** — the boot routine that configures both object stores against OpenRegister and primes settings before the UI renders.
+
+Source: openspec/coverage-report.md generated 2026-05-25. See the retrofit playbook.

--- a/openspec/changes/archive/retrofit-2026-05-25-app-shell-and-data-store/specs/app-shell-and-data-store/spec.md
+++ b/openspec/changes/archive/retrofit-2026-05-25-app-shell-and-data-store/specs/app-shell-and-data-store/spec.md
@@ -1,0 +1,104 @@
+---
+retrofit: true
+---
+
+# App Shell & Data Store — Retrofit Spec
+
+This is a new capability describing the Planix application shell — the backend
+controller that serves the single-page application and the generic frontend
+OpenRegister object store that the shell boots. The behavior already ships on
+`development`; this spec retroactively captures it because the SPA-serving
+controller and the generic object-store module had no owning REQ (previously
+unannotatable).
+
+## Implementation Requirements
+
+### Requirement: SPA Page Serving [MVP]
+
+The system MUST serve the Planix single-page application from a backend
+controller, both for the root page and for Vue history-mode deep links, so a
+bookmarked or refreshed in-app URL resolves to the same SPA shell.
+
+#### Scenario: Render the dashboard page
+
+- GIVEN an authenticated Nextcloud user
+- WHEN they request the Planix root page route
+- THEN `DashboardController::page()` MUST return a `TemplateResponse` for the
+  `index` template of the `planix` app
+- AND the route MUST be annotated `@NoAdminRequired` and `@NoCSRFRequired` so
+  any authenticated user can load the shell
+
+#### Scenario: Serve the SPA for a deep link
+
+- GIVEN an authenticated user navigates directly to an in-app route
+  (e.g. `/projects/:id/backlog`) handled by Vue history mode
+- WHEN the server receives the request
+- THEN `DashboardController::catchAll()` MUST delegate to `page()` and return
+  the same `index` `TemplateResponse`
+- AND the client-side router MUST then resolve the deep-link route
+
+#### Notes
+
+- `catchAll()` is a pure delegation to `page()` — both return an identical
+  shell; the actual routing happens client-side.
+
+---
+
+### Requirement: Generic OpenRegister Object Store [MVP]
+
+The frontend MUST provide a configurable, type-registered Pinia object store
+that reads object collections from OpenRegister, so feature stores can fetch
+any registered schema/register pair without duplicating fetch plumbing.
+
+#### Scenario: Configure base URLs
+
+- GIVEN the object store is freshly created
+- WHEN `configure({ baseUrl, schemaBaseUrl })` is called
+- THEN the store MUST persist `baseUrl` and `schemaBaseUrl` for use by
+  subsequent fetches
+
+#### Scenario: Register an object type
+
+- GIVEN the object store is configured
+- WHEN `registerObjectType(type, schema, register)` is called
+- THEN the store MUST record the `{ schema, register }` pair under `type`
+- AND it MUST initialise an empty objects array for that type if none exists
+
+#### Scenario: Fetch a typed collection
+
+- GIVEN a type has been registered
+- WHEN `fetchObjects(type, params)` is called
+- THEN the store MUST issue a GET to `baseUrl` with `register`, `schema`, and
+  any extra `params` as query parameters, including the Nextcloud request token
+- AND on a successful response it MUST store and return `data.results` (or the
+  raw body when `results` is absent)
+- AND on an unregistered type it MUST warn and return an empty array without
+  issuing a request
+- AND on a network/parse error it MUST log the error and return an empty array
+- AND it MUST toggle the per-type `loading` flag around the request
+
+---
+
+### Requirement: Store Bootstrap [MVP]
+
+The system MUST run a single boot routine that wires the OpenRegister object
+stores and primes settings before the UI renders, so views can assume a
+configured data layer.
+
+#### Scenario: Initialize stores on app boot
+
+- GIVEN the Planix app (or admin settings root) is mounting
+- WHEN `initializeStores()` runs
+- THEN it MUST `configure()` the local object store with the OpenRegister
+  objects and schemas base URLs
+- AND it MUST `configure()` the shared `@conduction/nextcloud-vue` object store
+  with the OpenRegister objects base URL
+- AND it MUST await `settingsStore.fetchSettings()` so OpenRegister
+  availability and admin flags are known before render
+- AND it MUST return the settings and object store handles
+
+#### Notes
+
+- Two object stores are configured: the app-local `src/store/modules/object.js`
+  store and the shared `@conduction/nextcloud-vue` store used by the projects
+  store. Both point at the same OpenRegister objects endpoint.

--- a/openspec/changes/archive/retrofit-2026-05-25-app-shell-and-data-store/tasks.md
+++ b/openspec/changes/archive/retrofit-2026-05-25-app-shell-and-data-store/tasks.md
@@ -1,0 +1,5 @@
+# Tasks
+
+- [x] task-1: app-shell-and-data-store#REQ-SPA-Page-Serving — SPA Page Serving (retroactive annotation)
+- [x] task-2: app-shell-and-data-store#REQ-Generic-Object-Store — Generic OpenRegister Object Store (retroactive annotation)
+- [x] task-3: app-shell-and-data-store#REQ-Store-Bootstrap — Store Bootstrap (retroactive annotation)

--- a/openspec/specs/app-shell-and-data-store.md
+++ b/openspec/specs/app-shell-and-data-store.md
@@ -1,0 +1,131 @@
+---
+retrofit: true
+---
+
+# App Shell & Data Store Specification
+
+**Status**: done
+
+**Standards**: Nextcloud OCP\AppFramework (TemplateResponse), OpenRegister objects API, Pinia
+**Feature tier**: MVP
+
+**OpenSpec changes:**
+- [retrofit-2026-05-25-app-shell-and-data-store](../changes/archive/retrofit-2026-05-25-app-shell-and-data-store/) — reverse-spec of the SPA-serving controller and the generic OpenRegister object store
+
+## Purpose
+
+This capability describes the Planix application shell — the backend controller
+that serves the single-page application (including Vue history-mode deep links)
+and the generic frontend OpenRegister object store that the shell boots. It is
+the foundational layer that every feature spec (`projects`, `dashboard-my-work`,
+`admin-user-settings`) sits on top of: the SPA must be served, and a configured
+data store must exist, before any feature renders.
+
+## Data Model
+
+No OpenRegister entities of its own. The object store is generic plumbing over
+the OpenRegister objects API, parameterised by `register` + `schema` per
+registered type.
+
+## Implementation Requirements
+
+### Requirement: SPA Page Serving [MVP]
+
+The system MUST serve the Planix single-page application from a backend
+controller, both for the root page and for Vue history-mode deep links, so a
+bookmarked or refreshed in-app URL resolves to the same SPA shell.
+
+#### Scenario: Render the dashboard page
+
+- GIVEN an authenticated Nextcloud user
+- WHEN they request the Planix root page route
+- THEN `DashboardController::page()` MUST return a `TemplateResponse` for the
+  `index` template of the `planix` app
+- AND the route MUST be annotated `@NoAdminRequired` and `@NoCSRFRequired` so
+  any authenticated user can load the shell
+
+#### Scenario: Serve the SPA for a deep link
+
+- GIVEN an authenticated user navigates directly to an in-app route
+  (e.g. `/projects/:id/backlog`) handled by Vue history mode
+- WHEN the server receives the request
+- THEN `DashboardController::catchAll()` MUST delegate to `page()` and return
+  the same `index` `TemplateResponse`
+- AND the client-side router MUST then resolve the deep-link route
+
+#### Notes
+
+- `catchAll()` is a pure delegation to `page()` — both return an identical
+  shell; the actual routing happens client-side.
+
+---
+
+### Requirement: Generic OpenRegister Object Store [MVP]
+
+The frontend MUST provide a configurable, type-registered Pinia object store
+that reads object collections from OpenRegister, so feature stores can fetch
+any registered schema/register pair without duplicating fetch plumbing.
+
+#### Scenario: Configure base URLs
+
+- GIVEN the object store is freshly created
+- WHEN `configure({ baseUrl, schemaBaseUrl })` is called
+- THEN the store MUST persist `baseUrl` and `schemaBaseUrl` for use by
+  subsequent fetches
+
+#### Scenario: Register an object type
+
+- GIVEN the object store is configured
+- WHEN `registerObjectType(type, schema, register)` is called
+- THEN the store MUST record the `{ schema, register }` pair under `type`
+- AND it MUST initialise an empty objects array for that type if none exists
+
+#### Scenario: Fetch a typed collection
+
+- GIVEN a type has been registered
+- WHEN `fetchObjects(type, params)` is called
+- THEN the store MUST issue a GET to `baseUrl` with `register`, `schema`, and
+  any extra `params` as query parameters, including the Nextcloud request token
+- AND on a successful response it MUST store and return `data.results` (or the
+  raw body when `results` is absent)
+- AND on an unregistered type it MUST warn and return an empty array without
+  issuing a request
+- AND on a network/parse error it MUST log the error and return an empty array
+- AND it MUST toggle the per-type `loading` flag around the request
+
+---
+
+### Requirement: Store Bootstrap [MVP]
+
+The system MUST run a single boot routine that wires the OpenRegister object
+stores and primes settings before the UI renders, so views can assume a
+configured data layer.
+
+#### Scenario: Initialize stores on app boot
+
+- GIVEN the Planix app (or admin settings root) is mounting
+- WHEN `initializeStores()` runs
+- THEN it MUST `configure()` the local object store with the OpenRegister
+  objects and schemas base URLs
+- AND it MUST `configure()` the shared `@conduction/nextcloud-vue` object store
+  with the OpenRegister objects base URL
+- AND it MUST await `settingsStore.fetchSettings()` so OpenRegister
+  availability and admin flags are known before render
+- AND it MUST return the settings and object store handles
+
+#### Notes
+
+- Two object stores are configured: the app-local `src/store/modules/object.js`
+  store and the shared `@conduction/nextcloud-vue` store used by the projects
+  store. Both point at the same OpenRegister objects endpoint.
+- `fetchObjects` swallows network/parse errors and returns an empty array
+  rather than surfacing them — specified as observed behavior, flagged for
+  future tightening.
+
+## Acceptance Criteria
+
+- [ ] `DashboardController::page()` returns a `TemplateResponse` for the `index` template
+- [ ] `DashboardController::catchAll()` delegates to `page()` for deep links
+- [ ] `object.js` store exposes `configure`, `registerObjectType`, `fetchObjects`
+- [ ] `fetchObjects` returns `[]` for unregistered types and on error
+- [ ] `initializeStores()` configures both object stores and awaits settings fetch

--- a/src/App.vue
+++ b/src/App.vue
@@ -72,6 +72,9 @@ export default {
 		UserSettings,
 	},
 
+	/**
+	 * @spec exclude Framework glue — provides setSidebar/closeSidebar inject callbacks; no observable behavior.
+	 */
 	provide() {
 		return {
 			// Views can call this.setSidebar(componentDefinition) to render a sidebar.
@@ -94,22 +97,37 @@ export default {
 	},
 
 	computed: {
+		/**
+		 * @spec exclude Store passthrough — proxies settingsStore.hasOpenRegisters.
+		 */
 		hasOpenRegisters() {
 			const settingsStore = useSettingsStore()
 			return settingsStore.hasOpenRegisters
 		},
+		/**
+		 * @spec exclude Store passthrough — proxies settingsStore.getIsAdmin.
+		 */
 		isAdmin() {
 			const settingsStore = useSettingsStore()
 			return settingsStore.getIsAdmin
 		},
+		/**
+		 * @spec exclude Trivial asset-path getter — resolves the app-dark.svg image path.
+		 */
 		appIcon() {
 			return imagePath('planix', 'app-dark.svg')
 		},
+		/**
+		 * @spec exclude Trivial URL getter — builds the OpenRegister app-store link.
+		 */
 		appStoreUrl() {
 			return generateUrl('/settings/apps/integration/openregister')
 		},
 	},
 
+	/**
+	 * @spec exclude Lifecycle bootstrap — awaits initializeStores() then flips storesReady; store wiring is spec'd in app-shell-and-data-store.
+	 */
 	async created() {
 		await initializeStores()
 		this.storesReady = true

--- a/src/components/MemberSearch.vue
+++ b/src/components/MemberSearch.vue
@@ -79,6 +79,9 @@ export default {
 	},
 
 	methods: {
+		/**
+		 * @spec exclude Event-wiring glue — debounces input and delegates to searchUsers (covered by task-10).
+		 */
 		onInput(value) {
 			this.query = value
 			this.searched = false

--- a/src/components/ProjectListItem.vue
+++ b/src/components/ProjectListItem.vue
@@ -56,10 +56,16 @@ export default {
 	emits: ['click'],
 
 	computed: {
+		/**
+		 * @spec exclude Trivial display formatter — counts the members array length.
+		 */
 		memberCount() {
 			return Array.isArray(this.project.members) ? this.project.members.length : 0
 		},
 
+		/**
+		 * @spec exclude Trivial display formatter — maps status to a translated label.
+		 */
 		statusLabel() {
 			const map = {
 				active: this.t('planix', 'Active'),
@@ -69,6 +75,9 @@ export default {
 			return map[this.project.status] || this.project.status || this.t('planix', 'Active')
 		},
 
+		/**
+		 * @spec exclude Trivial display formatter — maps status to an NcChip type.
+		 */
 		statusType() {
 			const map = { active: 'success', archived: 'warning', completed: 'default' }
 			return map[this.project.status] || 'default'

--- a/src/components/ProjectSettingsSidebar.vue
+++ b/src/components/ProjectSettingsSidebar.vue
@@ -265,15 +265,24 @@ export default {
 	},
 
 	computed: {
+		/**
+		 * @spec exclude Store passthrough — returns the projects Pinia store.
+		 */
 		projectsStore() {
 			return useProjectsStore()
 		},
+		/**
+		 * @spec exclude Auth passthrough — returns the current user's UID.
+		 */
 		currentUid() {
 			return getCurrentUser()?.uid || ''
 		},
 	},
 
 	watch: {
+		/**
+		 * @spec exclude Framework glue — syncs the project prop into the edit form on change.
+		 */
 		project(newVal) {
 			if (newVal) {
 				this.form.title = newVal.title || ''
@@ -309,6 +318,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude Event-wiring glue — refreshes the project after a member is added.
+		 */
 		onMemberAdded() {
 			this.projectsStore.fetchProject(this.project.id)
 		},
@@ -336,6 +348,12 @@ export default {
 			await this.projectsStore.fetchProject(this.project.id)
 		},
 
+		/**
+		 * Confirm a pending member removal after the assigned-task warning —
+		 * removes the member and refreshes the project.
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-24-annotate-planix/tasks.md#task-10
+		 */
 		async executeRemoval() {
 			if (this.pendingRemoveUid) {
 				await this.projectsStore.removeMember(this.project.id, this.pendingRemoveUid)
@@ -344,6 +362,9 @@ export default {
 			this.cancelRemoval()
 		},
 
+		/**
+		 * @spec exclude State-reset glue — clears the pending member-removal warning.
+		 */
 		cancelRemoval() {
 			this.removalWarning = null
 			this.pendingRemoveUid = null
@@ -363,12 +384,18 @@ export default {
 			this.confirmArchive = false
 		},
 
+		/**
+		 * @spec exclude Event-wiring glue — closes the sidebar and routes to Projects after leaving.
+		 */
 		onLeft() {
 			this.showLeaveDialog = false
 			this.$emit('close')
 			this.$router.push({ name: 'Projects' })
 		},
 
+		/**
+		 * @spec exclude Event-wiring glue — re-emits deleted/close after a project delete.
+		 */
 		onDeleted() {
 			this.showDeleteDialog = false
 			this.$emit('deleted')

--- a/src/components/dialogs/ProjectCreationDialog.vue
+++ b/src/components/dialogs/ProjectCreationDialog.vue
@@ -117,9 +117,15 @@ export default {
 	},
 
 	computed: {
+		/**
+		 * @spec exclude Store passthrough — returns the projects Pinia store.
+		 */
 		projectsStore() {
 			return useProjectsStore()
 		},
+		/**
+		 * @spec exclude Store passthrough — proxies projectsStore.loading.
+		 */
 		loading() {
 			return this.projectsStore.loading
 		},
@@ -128,6 +134,9 @@ export default {
 		},
 	},
 
+	/**
+	 * @spec exclude Lifecycle glue — autofocuses the title field on mount.
+	 */
 	mounted() {
 		this.$nextTick(() => {
 			this.$refs.titleField?.$el?.querySelector('input')?.focus()

--- a/src/components/dialogs/ProjectDeleteDialog.vue
+++ b/src/components/dialogs/ProjectDeleteDialog.vue
@@ -62,6 +62,11 @@ export default {
 		}
 	},
 
+	/**
+	 * Load the project's task count to populate the cascade-delete warning.
+	 *
+	 * @spec openspec/changes/retrofit-2026-05-24-annotate-planix/tasks.md#task-9
+	 */
 	async mounted() {
 		const store = useProjectsStore()
 		this.taskCount = await store.getTaskCount(this.project.id)
@@ -69,6 +74,11 @@ export default {
 	},
 
 	methods: {
+		/**
+		 * Confirm and execute the cascade deletion of the project.
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-24-annotate-planix/tasks.md#task-9
+		 */
 		async confirm() {
 			this.loading = true
 			try {

--- a/src/components/dialogs/ProjectLeaveDialog.vue
+++ b/src/components/dialogs/ProjectLeaveDialog.vue
@@ -63,6 +63,12 @@ export default {
 		}
 	},
 
+	/**
+	 * Probe whether leaving would remove the last member, to show the
+	 * last-member warning before confirmation.
+	 *
+	 * @spec openspec/changes/retrofit-2026-05-24-annotate-planix/tasks.md#task-10
+	 */
 	async mounted() {
 		const store = useProjectsStore()
 		const result = await store.leaveProject(this.projectId)
@@ -73,6 +79,11 @@ export default {
 	},
 
 	methods: {
+		/**
+		 * Confirm leaving the project by removing the current user as a member.
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-24-annotate-planix/tasks.md#task-10
+		 */
 		async confirm() {
 			this.loading = true
 			try {

--- a/src/navigation/MainMenu.vue
+++ b/src/navigation/MainMenu.vue
@@ -57,6 +57,9 @@ export default {
 		HomeIcon,
 	},
 	methods: {
+		/**
+		 * @spec exclude Trivial helper — opens an external URL via window.open.
+		 */
 		openLink(url, target = '_blank') {
 			window.open(url, target)
 		},

--- a/src/store/modules/object.js
+++ b/src/store/modules/object.js
@@ -14,11 +14,30 @@ export const useObjectStore = defineStore('object', {
 	}),
 
 	actions: {
+		/**
+		 * Set the OpenRegister objects and schemas base URLs on the store.
+		 *
+		 * @param {object} options              Configuration options
+		 * @param {string} options.baseUrl       OpenRegister objects endpoint
+		 * @param {string} options.schemaBaseUrl OpenRegister schemas endpoint
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-25-app-shell-and-data-store/tasks.md#task-2
+		 */
 		configure({ baseUrl, schemaBaseUrl }) {
 			this.baseUrl = baseUrl
 			this.schemaBaseUrl = schemaBaseUrl
 		},
 
+		/**
+		 * Register a schema/register pair under a type key, initialising an
+		 * empty objects array for the type if none exists.
+		 *
+		 * @param {string} type     Local type key
+		 * @param {string} schema   OpenRegister schema slug
+		 * @param {string} register OpenRegister register slug
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-25-app-shell-and-data-store/tasks.md#task-2
+		 */
 		registerObjectType(type, schema, register) {
 			this.objectTypes[type] = { schema, register }
 			if (!this.objects[type]) {
@@ -26,6 +45,17 @@ export const useObjectStore = defineStore('object', {
 			}
 		},
 
+		/**
+		 * Fetch a typed object collection from OpenRegister. Returns an empty
+		 * array for unregistered types or on error; toggles the per-type
+		 * loading flag around the request.
+		 *
+		 * @param {string} type   Registered type key
+		 * @param {object} params Extra query parameters
+		 * @return {Promise<Array>}
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-25-app-shell-and-data-store/tasks.md#task-2
+		 */
 		async fetchObjects(type, params = {}) {
 			if (!this.objectTypes[type]) {
 				console.warn(`Object type "${type}" is not registered`)

--- a/src/store/projects.js
+++ b/src/store/projects.js
@@ -54,6 +54,9 @@ export const useProjectsStore = defineStore('projects', {
 	actions: {
 		// ── Internal helpers ──────────────────────────────────────────────
 
+		/**
+		 * @spec exclude Internal helper — lazily registers Planix schemas on the shared object store and returns it.
+		 */
 		_objectStore() {
 			const store = useObjectStore()
 			// Register types if not yet registered.
@@ -72,6 +75,9 @@ export const useProjectsStore = defineStore('projects', {
 			return store
 		},
 
+		/**
+		 * @spec exclude Auth passthrough — returns the current user's UID.
+		 */
 		_currentUid() {
 			return getCurrentUser()?.uid || ''
 		},
@@ -453,6 +459,8 @@ export const useProjectsStore = defineStore('projects', {
 		 *
 		 * @param {string} projectId Project ID
 		 * @return {Promise<number>}
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-24-annotate-planix/tasks.md#task-9
 		 */
 		async getTaskCount(projectId) {
 			try {

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -3,6 +3,14 @@ import { useObjectStore } from './modules/object.js'
 import { useObjectStore as useConductionObjectStore } from '@conduction/nextcloud-vue'
 import { useSettingsStore } from './modules/settings.js'
 
+/**
+ * Boot routine that configures both OpenRegister object stores against the
+ * OpenRegister endpoints and primes settings before the UI renders.
+ *
+ * @return {Promise<{settingsStore: object, objectStore: object}>}
+ *
+ * @spec openspec/changes/retrofit-2026-05-25-app-shell-and-data-store/tasks.md#task-3
+ */
 export async function initializeStores() {
 	const settingsStore = useSettingsStore()
 	const objectStore = useObjectStore()

--- a/src/views/ProjectBacklog.vue
+++ b/src/views/ProjectBacklog.vue
@@ -57,9 +57,15 @@ export default {
 	},
 
 	computed: {
+		/**
+		 * @spec exclude Store passthrough — returns the projects Pinia store.
+		 */
 		projectsStore() {
 			return useProjectsStore()
 		},
+		/**
+		 * @spec exclude Trivial display getter — active project title with UUID fallback.
+		 */
 		projectTitle() {
 			return this.projectsStore.activeProject?.title || this.$route.params.id
 		},

--- a/src/views/ProjectBoard.vue
+++ b/src/views/ProjectBoard.vue
@@ -113,15 +113,33 @@ export default {
 	},
 
 	computed: {
+		/**
+		 * @spec exclude Store passthrough — returns the projects Pinia store.
+		 */
 		projectsStore() {
 			return useProjectsStore()
 		},
+		/**
+		 * @spec exclude Store passthrough — proxies projectsStore.activeProject.
+		 */
 		project() {
 			return this.projectsStore.activeProject
 		},
+		/**
+		 * @spec exclude Store passthrough — proxies projectsStore.loading.
+		 */
 		loading() {
 			return this.projectsStore.loading
 		},
+		/**
+		 * Whether the current user is denied access to the project — true on a
+		 * stored 403 (`forbidden`) or when the loaded project's members array
+		 * does not include the current user's UID.
+		 *
+		 * @return {boolean}
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-24-annotate-planix/tasks.md#task-10
+		 */
 		accessDenied() {
 			const store = this.projectsStore
 			if (store.error === 'forbidden') return true
@@ -133,6 +151,9 @@ export default {
 		},
 	},
 
+	/**
+	 * @spec exclude Lifecycle glue — fetches the route's project on mount; fetch behavior is spec'd in projects#REQ-Project-Lifecycle.
+	 */
 	async mounted() {
 		const id = this.$route.params.id
 		await this.projectsStore.fetchProject(id)

--- a/src/views/ProjectList.vue
+++ b/src/views/ProjectList.vue
@@ -136,6 +136,9 @@ export default {
 		ProjectCreationDialog,
 	},
 
+	/**
+	 * @spec exclude Composable-wiring glue — instantiates useListView for search/filter state.
+	 */
 	setup() {
 		// useListView manages search term and filter state per spec requirement.
 		// fetchFn is provided as a no-op because filtering is done client-side;
@@ -152,19 +155,34 @@ export default {
 	},
 
 	computed: {
+		/**
+		 * @spec exclude Store passthrough — returns the projects Pinia store.
+		 */
 		projectsStore() {
 			return useProjectsStore()
 		},
+		/**
+		 * @spec exclude Store passthrough — proxies projectsStore.projects.
+		 */
 		projects() {
 			return this.projectsStore.projects
 		},
+		/**
+		 * @spec exclude Store passthrough — proxies projectsStore.loading.
+		 */
 		loading() {
 			return this.projectsStore.loading
 		},
+		/**
+		 * @spec exclude Store passthrough — proxies projectsStore.error.
+		 */
 		error() {
 			return this.projectsStore.error
 		},
 
+		/**
+		 * @spec exclude Static config getter — returns the translated status filter chip definitions.
+		 */
 		statusChips() {
 			return [
 				{ value: null, label: this.t('planix', 'All') },
@@ -174,6 +192,14 @@ export default {
 			]
 		},
 
+		/**
+		 * Client-side filtered project list — applies the active status filter
+		 * and the useListView search term (title/description, case-insensitive).
+		 *
+		 * @return {Array}
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-24-annotate-planix/tasks.md#task-11
+		 */
 		// Client-side filter — uses useListView's searchTerm and local activeStatus.
 		filteredProjects() {
 			let list = this.projects

--- a/src/views/settings/AdminRoot.vue
+++ b/src/views/settings/AdminRoot.vue
@@ -44,6 +44,9 @@ export default {
 			appVersion: document.getElementById('planix-settings')?.dataset?.version || 'Unknown',
 		}
 	},
+	/**
+	 * @spec exclude Lifecycle bootstrap — awaits initializeStores() then flips storesReady; store wiring is spec'd in app-shell-and-data-store.
+	 */
 	async created() {
 		await initializeStores()
 		this.storesReady = true

--- a/src/views/settings/Settings.vue
+++ b/src/views/settings/Settings.vue
@@ -157,16 +157,30 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * @spec exclude Store passthrough — proxies the settings store's settings object.
+		 */
 		settings() {
 			return useSettingsStore().settings || {}
 		},
 	},
+	/**
+	 * @spec exclude Lifecycle glue — seeds the form fields from the settings store on create.
+	 */
 	created() {
 		const settingsStore = useSettingsStore()
 		this.form.register = settingsStore.settings?.register || ''
 		this.loadColumnList(settingsStore.settings)
 	},
 	methods: {
+		/**
+		 * Parse the stored default_columns JSON into the editable list,
+		 * falling back to the hardcoded default set on parse failure.
+		 *
+		 * @param {object} settings Settings object holding default_columns
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-24-annotate-planix/tasks.md#task-4
+		 */
 		loadColumnList(settings) {
 			try {
 				const raw = settings?.default_columns || '["To Do","In Progress","Review","Done"]'
@@ -175,12 +189,32 @@ export default {
 				this.columnList = ['To Do', 'In Progress', 'Review', 'Done']
 			}
 		},
+		/**
+		 * Append an empty column to the editable default-columns list.
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-24-annotate-planix/tasks.md#task-4
+		 */
 		addColumn() {
 			this.columnList.push('')
 		},
+		/**
+		 * Remove the column at the given index from the editable list.
+		 *
+		 * @param {number} index Index of the column to remove
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-24-annotate-planix/tasks.md#task-4
+		 */
 		removeColumn(index) {
 			this.columnList.splice(index, 1)
 		},
+		/**
+		 * Reorder a column up or down within the editable list.
+		 *
+		 * @param {number} index     Index of the column to move
+		 * @param {number} direction -1 to move up, +1 to move down
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-24-annotate-planix/tasks.md#task-4
+		 */
 		moveColumn(index, direction) {
 			const target = index + direction
 			if (target < 0 || target >= this.columnList.length) {
@@ -235,6 +269,11 @@ export default {
 			}
 			this.initializing = false
 		},
+		/**
+		 * Persist the legacy register-id field via settingsStore.saveSettings.
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-24-annotate-planix/tasks.md#task-4
+		 */
 		async save() {
 			this.saving = true
 			this.successMessage = ''


### PR DESCRIPTION
## Retrofit — Coverage to Zero

Drives planix spec-coverage from **57 uncovered methods (2 backend + 55 frontend) to 0**.

### Bucket 1 — annotate behavior matching existing REQs
Annotated to the archived `retrofit-2026-05-24-annotate-planix` change tasks:
- **Settings.vue** column editor (`addColumn`/`removeColumn`/`moveColumn`/`loadColumnList`/`save`) → task-4 (Admin Settings Page → configure default columns)
- **ProjectBoard.accessDenied** → task-10 (Member Management — 403/membership gate)
- **ProjectList.filteredProjects** → task-11 (Project List UI — search/filter)
- **projects.js getTaskCount** → task-9 (Project Deletion)
- **ProjectSettingsSidebar.executeRemoval** → task-10
- **ProjectDeleteDialog** `confirm`/`mounted` → task-9
- **ProjectLeaveDialog** `confirm`/`mounted` → task-10

### Reverse-spec — new `app-shell-and-data-store` capability (3 REQs / 6 methods)
Ghost change `retrofit-2026-05-25-app-shell-and-data-store` (archived):
- **REQ-SPA-Page-Serving** — `DashboardController::page`/`catchAll`
- **REQ-Generic-Object-Store** — `object.js` `configure`/`registerObjectType`/`fetchObjects`
- **REQ-Store-Bootstrap** — `store.js` `initializeStores`

### `@spec exclude` — framework glue (reason on each)
Store/auth passthroughs, lifecycle bootstrap, trivial display formatters, event-wiring across App.vue, MemberSearch, ProjectListItem, ProjectSettingsSidebar, the dialogs, MainMenu, the views, and the stores.

### What this PR does NOT do
- No code-behavior changes — all code edits are docblock additions.
- Does not silently fix observed behavior. Flagged in spec notes: `fetchObjects` swallows errors and returns `[]`.

### Verification
`python3 csc.py <worktree> --mode report` → **uncovered_count: 0**