### PR TITLE
fix(ui): bump @nextcloud/vue to ^8.39.0 (nav corner sliver on NC<34)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@nextcloud/initial-state": "^2.2.0",
         "@nextcloud/l10n": "3.4.1",
         "@nextcloud/router": "^3.1.0",
-        "@nextcloud/vue": "^8.16.0",
+        "@nextcloud/vue": "^8.39.0",
         "pinia": "^2.1.7",
         "vue": "^2.7.14",
         "vue-material-design-icons": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@nextcloud/initial-state": "^2.2.0",
     "@nextcloud/l10n": "3.4.1",
     "@nextcloud/router": "^3.1.0",
-    "@nextcloud/vue": "^8.16.0",
+    "@nextcloud/vue": "^8.39.0",
     "pinia": "^2.1.7",
     "vue": "^2.7.14",
     "vue-material-design-icons": "^5.3.0",


### PR DESCRIPTION
## What

Bumps the direct `@nextcloud/vue` dependency from `^8.16.0` to `^8.39.0` (resolved `8.39.0` in `package-lock.json`).

## Why

Nextcloud 34 introduced a rounded `.app-content` corner treatment. `@nextcloud/vue` versions before `8.39.0` rendered that NC34 rounded-corner styling unconditionally, which on **Nextcloud < 34** produced a white-sliver artifact in the navigation corner where the rounded `.app-content` overlaps the (still square) nav/header.

`@nextcloud/vue@8.39.0` adds an `isLegacy34` guard so the rounded-corner styling only applies on NC >= 34, eliminating the sliver on older Nextcloud versions.

## Change scope

- Bumped the direct `@nextcloud/vue` dependency pin.
- Regenerated `package-lock.json` (no `@nextcloud/vue` entry exists in `overrides`, so only the direct dep + lockfile change).
- The webpack bundle (`js/`) is gitignored, so the only committed changes are `package.json` + `package-lock.json`.

Part of a fleet-wide sweep to bring all Conduction apps onto `@nextcloud/vue@^8.39.0`.