### PR TITLE
docs(spec): convert display-capability excludes to specs (strict coverage)

### DIFF
--- a/openspec/changes/retrofit-2026-05-26-planix-display-capabilities/proposal.md
+++ b/openspec/changes/retrofit-2026-05-26-planix-display-capabilities/proposal.md
@@ -1,0 +1,79 @@
+# Proposal: Planix Display Capabilities (Retrofit)
+
+## Summary
+
+Retroactively capture four project-list display behaviors in Planix that were
+previously marked `@spec exclude` under an early, looser coverage policy. These
+methods are not framework plumbing — they encode product behavior (which
+project statuses exist, their human-readable labels, their chip semantics, the
+available status filters, and the member-count figure shown per project). Under
+the current strict policy, true capabilities must carry a spec; only genuine
+framework plumbing may stay excluded.
+
+## Motivation
+
+The methods below transform or encode product meaning and therefore belong in
+the spec, not behind an exclude marker:
+
+- `ProjectListItem.statusLabel` — maps each `status` enum value to a translated
+  label. This encodes the set of known statuses and their user-facing names.
+- `ProjectListItem.statusType` — maps each `status` to an `NcChip` type
+  (`success` / `warning` / `default`). This encodes status semantics.
+- `ProjectList.statusChips` — defines the status-filter chip set shown above the
+  project list. This encodes the available filters.
+- `ProjectListItem.memberCount` — surfaces the per-project member count, a
+  product-meaningful figure shown on every list row.
+
+These behaviors already ship on `development`; this change captures them so the
+strict spec-coverage gate reflects them as real capabilities rather than hidden
+gaps.
+
+## Affected Projects
+
+- [x] Project: `planix` — Frontend-only: retroactive spec annotation, no code behavior change
+
+## Scope
+
+### In Scope
+
+- A new `project-display` capability delta with four requirements describing the
+  existing display behaviors
+- Replacing the four `@spec exclude` markers with `@spec openspec/...` references
+
+### Out of Scope
+
+- Any change to the runtime behavior of the four methods
+- The genuine-plumbing excludes (store/auth passthroughs, provide/inject,
+  asset-path/URL builders, lifecycle bootstraps, event-wiring glue) which
+  correctly remain excluded
+
+## Approach
+
+Document the observed behavior of each method as a SHALL/MUST requirement with
+scenarios covering each enum branch and the fallback. Then point each method's
+docblock `@spec` line at the corresponding task. No code logic changes.
+
+## New Dependencies
+
+None
+
+## Impact
+
+- `src/components/ProjectListItem.vue` — `memberCount`, `statusLabel`, `statusType` annotations updated
+- `src/views/ProjectList.vue` — `statusChips` annotation updated
+- New spec delta `openspec/changes/.../specs/project-display/spec.md`
+
+## Cross-Project Dependencies
+
+None
+
+## Risks
+
+### Risk 1: Spec drift from code
+**Severity:** Low — **Mitigation:** Scenarios enumerate the exact status keys
+and labels present in the code; any future status addition must update both.
+
+## Rollback Strategy
+
+Revert the single commit. Purely additive spec + annotation changes; no runtime
+behavior is affected.

--- a/openspec/changes/retrofit-2026-05-26-planix-display-capabilities/specs/project-display/spec.md
+++ b/openspec/changes/retrofit-2026-05-26-planix-display-capabilities/specs/project-display/spec.md
@@ -1,0 +1,138 @@
+# Project Display Specification (Delta)
+
+**Status**: in-progress
+**Scope**: planix
+**OpenSpec changes**:
+- [retrofit-2026-05-26-planix-display-capabilities](../../) — retroactively captures project-list display behaviors
+
+## Purpose
+
+Defines how Planix presents a project's status and membership in the project
+list. These behaviors encode product meaning — the set of known statuses, their
+human-readable labels, their chip semantics, the available status filters, and
+the per-project member count — and are therefore specified rather than treated
+as framework plumbing.
+
+## ADDED Requirements
+
+### Requirement: Project status label mapping (REQ-PXD-001)
+The project list item MUST map each project `status` value to a translated,
+human-readable label.
+
+- `active` MUST render as the translated label "Active".
+- `archived` MUST render as the translated label "Archived".
+- `completed` MUST render as the translated label "Completed".
+- Any unknown or empty `status` MUST fall back to the raw status string, or to
+  the translated label "Active" when the status is empty.
+
+Labels MUST be translatable (ADR-007), supporting at minimum Dutch and English.
+
+#### Scenario: Active status
+- GIVEN a project with `status` = `active`
+- WHEN the project list item computes its status label
+- THEN it MUST return the translated "Active" label
+
+#### Scenario: Archived status
+- GIVEN a project with `status` = `archived`
+- WHEN the project list item computes its status label
+- THEN it MUST return the translated "Archived" label
+
+#### Scenario: Completed status
+- GIVEN a project with `status` = `completed`
+- WHEN the project list item computes its status label
+- THEN it MUST return the translated "Completed" label
+
+#### Scenario: Unknown status falls back to raw value
+- GIVEN a project with `status` = `on-hold` (not a known value)
+- WHEN the project list item computes its status label
+- THEN it MUST return the raw string `on-hold`
+
+#### Scenario: Empty status falls back to Active
+- GIVEN a project with no `status` set (null or empty)
+- WHEN the project list item computes its status label
+- THEN it MUST return the translated "Active" label
+
+### Requirement: Project status chip type mapping (REQ-PXD-002)
+The project list item MUST map each project `status` to an `NcChip` type that
+conveys the status semantics.
+
+- `active` MUST map to chip type `success`.
+- `archived` MUST map to chip type `warning`.
+- `completed` MUST map to chip type `default`.
+- Any unknown or empty `status` MUST map to chip type `default`.
+
+#### Scenario: Active status is a success chip
+- GIVEN a project with `status` = `active`
+- WHEN the project list item computes its chip type
+- THEN it MUST return `success`
+
+#### Scenario: Archived status is a warning chip
+- GIVEN a project with `status` = `archived`
+- WHEN the project list item computes its chip type
+- THEN it MUST return `warning`
+
+#### Scenario: Completed status is a default chip
+- GIVEN a project with `status` = `completed`
+- WHEN the project list item computes its chip type
+- THEN it MUST return `default`
+
+#### Scenario: Unknown status is a default chip
+- GIVEN a project with an unrecognized `status`
+- WHEN the project list item computes its chip type
+- THEN it MUST return `default`
+
+### Requirement: Project status filter chips (REQ-PXD-003)
+The project list view MUST present a fixed set of status-filter chips above the
+list, defining which statuses a user can filter by.
+
+The chip set MUST contain, in order:
+- "All" with filter value `null` (no filtering)
+- "Active" with filter value `active`
+- "Archived" with filter value `archived`
+- "Completed" with filter value `completed`
+
+All chip labels MUST be translatable (ADR-007).
+
+#### Scenario: Filter chip definitions
+- GIVEN the project list view is rendered
+- WHEN the status-filter chips are computed
+- THEN there MUST be exactly four chips
+- AND their values MUST be `null`, `active`, `archived`, `completed` in that order
+- AND their labels MUST be the translated "All", "Active", "Archived", "Completed"
+
+### Requirement: Project member count display (REQ-PXD-004)
+The project list item MUST surface the number of members on the project as a
+non-negative integer.
+
+- When `members` is an array, the count MUST equal the array length.
+- When `members` is missing or not an array, the count MUST be `0`.
+
+#### Scenario: Project with members
+- GIVEN a project whose `members` array contains 3 entries
+- WHEN the project list item computes its member count
+- THEN it MUST return `3`
+
+#### Scenario: Project with no members array
+- GIVEN a project with no `members` property (null or undefined)
+- WHEN the project list item computes its member count
+- THEN it MUST return `0`
+
+## Non-Functional Requirements
+
+- **Internationalization:** All user-facing labels MUST support Dutch and
+  English (ADR-007).
+- **Accessibility:** Status MUST NOT be conveyed by chip color alone — the
+  translated status label always accompanies the chip (WCAG 1.4.1).
+
+## Acceptance Criteria
+
+- [x] `statusLabel` returns correct translated labels for all known statuses and both fallbacks
+- [x] `statusType` returns correct chip types for all known statuses and the fallback
+- [x] `statusChips` returns the four-chip filter definition in order
+- [x] `memberCount` returns the array length or `0`
+
+## Notes
+
+- The status enum (`active`, `archived`, `completed`) matches the Project schema
+  in `register-schemas`. Any future status addition MUST update REQ-PXD-001,
+  REQ-PXD-002, and REQ-PXD-003 together.

--- a/openspec/changes/retrofit-2026-05-26-planix-display-capabilities/tasks.md
+++ b/openspec/changes/retrofit-2026-05-26-planix-display-capabilities/tasks.md
@@ -1,0 +1,6 @@
+# Tasks
+
+- [x] task-1: project-display#REQ-PXD-001 — Project status label mapping (retroactive annotation of `ProjectListItem.statusLabel`)
+- [x] task-2: project-display#REQ-PXD-002 — Project status chip type mapping (retroactive annotation of `ProjectListItem.statusType`)
+- [x] task-3: project-display#REQ-PXD-003 — Project status filter chips (retroactive annotation of `ProjectList.statusChips`)
+- [x] task-4: project-display#REQ-PXD-004 — Project member count display (retroactive annotation of `ProjectListItem.memberCount`)

--- a/src/components/ProjectListItem.vue
+++ b/src/components/ProjectListItem.vue
@@ -57,14 +57,14 @@ export default {
 
 	computed: {
 		/**
-		 * @spec exclude Trivial display formatter — counts the members array length.
+		 * @spec openspec/changes/retrofit-2026-05-26-planix-display-capabilities/tasks.md#task-4
 		 */
 		memberCount() {
 			return Array.isArray(this.project.members) ? this.project.members.length : 0
 		},
 
 		/**
-		 * @spec exclude Trivial display formatter — maps status to a translated label.
+		 * @spec openspec/changes/retrofit-2026-05-26-planix-display-capabilities/tasks.md#task-1
 		 */
 		statusLabel() {
 			const map = {
@@ -76,7 +76,7 @@ export default {
 		},
 
 		/**
-		 * @spec exclude Trivial display formatter — maps status to an NcChip type.
+		 * @spec openspec/changes/retrofit-2026-05-26-planix-display-capabilities/tasks.md#task-2
 		 */
 		statusType() {
 			const map = { active: 'success', archived: 'warning', completed: 'default' }

--- a/src/views/ProjectList.vue
+++ b/src/views/ProjectList.vue
@@ -181,7 +181,7 @@ export default {
 		},
 
 		/**
-		 * @spec exclude Static config getter — returns the translated status filter chip definitions.
+		 * @spec openspec/changes/retrofit-2026-05-26-planix-display-capabilities/tasks.md#task-3
 		 */
 		statusChips() {
 			return [


### PR DESCRIPTION
## Summary

Tightens Planix's spec-coverage excludes under the new strict policy: write a spec for any method that is a true capability; reserve \`@spec exclude\` only for genuine framework plumbing.

Four project-list display methods were previously marked \`@spec exclude\` under the earlier looser policy. They transform/encode product behavior, so they are now captured as real requirements:

| Method | REQ | What it encodes |
|--------|-----|-----------------|
| \`ProjectListItem.statusLabel\` | REQ-PXD-001 | status → translated label (set of known statuses + names) |
| \`ProjectListItem.statusType\` | REQ-PXD-002 | status → NcChip type (status semantics) |
| \`ProjectList.statusChips\` | REQ-PXD-003 | available status-filter chip set |
| \`ProjectListItem.memberCount\` | REQ-PXD-004 | per-project member count figure |

New capability delta: \`openspec/changes/retrofit-2026-05-26-planix-display-capabilities/\` (4 REQs), \`openspec validate --strict\` green.

## Kept as genuine plumbing (unchanged)

Store/auth passthroughs, Vue \`provide()\` inject wiring, asset-path/URL builders, lifecycle bootstraps (only call already-spec'd \`initializeStores()\`/route fetch), and event-wiring/debounce/state-reset glue. 34 excludes retained.

## Coverage

\`uncovered_count\` = 0 before and after. No runtime behavior changed — spec annotation only.