### PR TITLE
fix: resolve hydra mechanical gate (initial-state)

### DIFF
--- a/lib/Settings/AdminSettings.php
+++ b/lib/Settings/AdminSettings.php
@@ -26,6 +26,7 @@ namespace OCA\Planix\Settings;
 use OCA\Planix\AppInfo\Application;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Http\TemplateResponse;
+use OCP\AppFramework\Services\IInitialState;
 use OCP\Settings\ISettings;
 
 /**
@@ -36,10 +37,12 @@ class AdminSettings implements ISettings
     /**
      * Constructor.
      *
-     * @param IAppManager $appManager The app manager.
+     * @param IAppManager   $appManager   The app manager.
+     * @param IInitialState $initialState The initial state service.
      */
     public function __construct(
         private IAppManager $appManager,
+        private IInitialState $initialState,
     ) {
     }//end __construct()
 
@@ -54,10 +57,12 @@ class AdminSettings implements ISettings
     {
         $version = $this->appManager->getAppVersion(appId: Application::APP_ID);
 
+        $this->initialState->provideInitialState('version', $version);
+
         return new TemplateResponse(
             Application::APP_ID,
             'settings/admin',
-            ['version' => $version]
+            []
         );
     }//end getForm()
 

--- a/src/views/settings/AdminRoot.vue
+++ b/src/views/settings/AdminRoot.vue
@@ -28,6 +28,7 @@
  *
  * @spec openspec/changes/retrofit-2026-05-24-annotate-planix/tasks.md#task-4
  */
+import { loadState } from '@nextcloud/initial-state'
 import { CnVersionInfoCard } from '@conduction/nextcloud-vue'
 import Settings from './Settings.vue'
 import { initializeStores } from '../../store/store.js'
@@ -41,7 +42,7 @@ export default {
 	data() {
 		return {
 			storesReady: false,
-			appVersion: document.getElementById('planix-settings')?.dataset?.version || 'Unknown',
+			appVersion: loadState('planix', 'version', 'Unknown'),
 		}
 	},
 	/**

--- a/templates/settings/admin.php
+++ b/templates/settings/admin.php
@@ -5,4 +5,4 @@ use OCP\Util;
 $appId = OCA\Planix\AppInfo\Application::APP_ID;
 Util::addScript($appId, $appId . '-settings');
 ?>
-<div id="planix-settings" data-version="<?php p($_['version'] ?? ''); ?>"></div>
+<div id="planix-settings"></div>


### PR DESCRIPTION
Bucket-A safe fix from the fleet-wide hydra-gates sweep: ADR-004 loadState/IInitialState for the settings app version. Security-semantic findings tracked in a separate backlog issue.