### PR TITLE
fix(security): clear Bucket-B (ADR-023 + auth/routing)

### DIFF
--- a/lib/Controller/HealthController.php
+++ b/lib/Controller/HealthController.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * Planix Health Controller
+ *
+ * Controller for exposing health check status.
+ *
+ * @category Controller
+ * @package  OCA\Planix\Controller
+ *
+ * @author    Conduction Development Team <dev@conductio.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://conduction.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Planix\Controller;
+
+use OCA\Planix\AppInfo\Application;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IDBConnection;
+use OCP\IRequest;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Controller for health check endpoint.
+ *
+ * Admin-only: no @NoAdminRequired — NC middleware enforces admin access.
+ */
+class HealthController extends Controller
+{
+    /**
+     * Constructor for the HealthController.
+     *
+     * @param IRequest        $request The request object
+     * @param IDBConnection   $db      The database connection
+     * @param LoggerInterface $logger  Logger for error reporting
+     *
+     * @return void
+     */
+    public function __construct(
+        IRequest $request,
+        private readonly IDBConnection $db,
+        private readonly LoggerInterface $logger,
+    ) {
+        parent::__construct(appName: Application::APP_ID, request: $request);
+    }//end __construct()
+
+    /**
+     * Return health check status.
+     *
+     * @NoCSRFRequired
+     *
+     * @return JSONResponse JSON response with health status and checks.
+     */
+    public function index(): JSONResponse
+    {
+        $checks = [];
+        $status = 'ok';
+
+        // Database check.
+        try {
+            $qb     = $this->db->getQueryBuilder();
+            $result = $qb->select($qb->createFunction('1'))->executeQuery();
+            $result->closeCursor();
+            $checks['database'] = 'ok';
+        } catch (\Exception $e) {
+            $checks['database'] = 'error';
+            $status             = 'error';
+            $this->logger->error(
+                'Planix health check: database failed',
+                ['exception' => $e->getMessage()]
+            );
+        }
+
+        return new JSONResponse(
+            [
+                'status' => $status,
+                'checks' => $checks,
+            ]
+        );
+    }//end index()
+}//end class

--- a/lib/Controller/MetricsController.php
+++ b/lib/Controller/MetricsController.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * Planix Metrics Controller
+ *
+ * Controller for exposing Prometheus metrics in text exposition format.
+ *
+ * @category Controller
+ * @package  OCA\Planix\Controller
+ *
+ * @author    Conduction Development Team <dev@conductio.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://conduction.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Planix\Controller;
+
+use OCA\Planix\AppInfo\Application;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\TextPlainResponse;
+use OCP\IConfig;
+use OCP\IRequest;
+
+/**
+ * Controller for exposing Prometheus metrics.
+ *
+ * Admin-only: no @NoAdminRequired — NC middleware enforces admin access.
+ */
+class MetricsController extends Controller
+{
+    /**
+     * Constructor for the MetricsController.
+     *
+     * @param IRequest $request The request object
+     * @param IConfig  $config  The config service
+     *
+     * @return void
+     */
+    public function __construct(
+        IRequest $request,
+        private readonly IConfig $config,
+    ) {
+        parent::__construct(appName: Application::APP_ID, request: $request);
+    }//end __construct()
+
+    /**
+     * Expose Prometheus metrics.
+     *
+     * @NoCSRFRequired
+     *
+     * @return TextPlainResponse Plain text response with Prometheus metrics.
+     */
+    public function index(): TextPlainResponse
+    {
+        $lines = [];
+
+        $appVersion = $this->config->getAppValue(Application::APP_ID, 'installed_version', '0.0.0');
+        $phpVersion = PHP_VERSION;
+        $ncVersion  = $this->config->getSystemValueString('version', '0.0.0');
+
+        // Info gauge.
+        $lines[] = '# HELP planix_info Application information';
+        $lines[] = '# TYPE planix_info gauge';
+        $labels  = sprintf(
+            'version="%s",php_version="%s",nextcloud_version="%s"',
+            $appVersion,
+            $phpVersion,
+            $ncVersion
+        );
+        $lines[] = 'planix_info{'.$labels.'} 1';
+
+        // Up gauge.
+        $lines[] = '# HELP planix_up Whether the application is up';
+        $lines[] = '# TYPE planix_up gauge';
+        $lines[] = 'planix_up 1';
+
+        $body     = implode("\n", $lines)."\n";
+        $response = new TextPlainResponse($body);
+        $response->addHeader('Content-Type', 'text/plain; version=0.0.4; charset=utf-8');
+
+        return $response;
+    }//end index()
+}//end class

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -30,6 +30,7 @@ use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
+use OCP\IUserSession;
 
 /**
  * Controller for managing Planix application settings.
@@ -41,18 +42,23 @@ class SettingsController extends Controller
      *
      * @param IRequest        $request         The request object
      * @param SettingsService $settingsService The settings service
+     * @param IUserSession    $userSession     The user session
      *
      * @return void
      */
     public function __construct(
         IRequest $request,
         private SettingsService $settingsService,
+        private IUserSession $userSession,
     ) {
         parent::__construct(appName: Application::APP_ID, request: $request);
     }//end __construct()
 
     /**
      * Retrieve all current settings.
+     *
+     * Returns app configuration including an isAdmin flag consumed by
+     * the frontend. Any authenticated user may read settings.
      *
      * @NoAdminRequired
      *
@@ -62,6 +68,10 @@ class SettingsController extends Controller
      */
     public function index(): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated.'], Http::STATUS_UNAUTHORIZED);
+        }
+
         return new JSONResponse(
             $this->settingsService->getSettings()
         );


### PR DESCRIPTION
## Summary

Clears all Bucket-B security findings on planix (pre-prod). All 18 hydra gates green after this PR.

## Gate before → after

| Gate | Before | After | Details |
|------|--------|-------|---------|
| Gate-5 route-auth | FAIL (2) | PASS | `health#index` and `metrics#index` were registered in `routes.php` but had no backing controller files; created both controllers |
| Gate-7 no-admin-idor | FAIL (1) | PASS | `SettingsController::index()` had `@NoAdminRequired` with no auth guard in body; added `IUserSession` 401 guard |

## Posture decisions

- **HealthController / MetricsController**: Admin-only (no `@NoAdminRequired`); `@NoCSRFRequired` only — NC middleware enforces admin access for observability endpoints. Follows mydash pattern.
- **SettingsController::index()**: READ posture — `@NoAdminRequired` + explicit `$this->userSession->getUser() === null → 401` guard. Any authenticated user may read settings (incl. `isAdmin` flag for frontend).

## Routes changed

No URLs or verbs were changed. Two previously-registered but unresolvable routes (`GET /api/health`, `GET /api/metrics`) now have backing implementations.

## ADR-023 kit ported?

No — planix has no ACTION endpoints requiring `requireAction()`; the kit was not needed.

## Verification

- All 18 hydra gates: GREEN
- `php -l`: clean (no syntax errors)
- `composer phpstan`: no errors

Refs #250