### PR TITLE
chore(spec): restore gate-16 coverage on health/metrics

### DIFF
--- a/lib/Controller/HealthController.php
+++ b/lib/Controller/HealthController.php
@@ -59,6 +59,8 @@ class HealthController extends Controller
      *
      * @NoCSRFRequired
      *
+     * @spec exclude observability endpoint per ADR-006 (health plumbing, no business capability)
+     *
      * @return JSONResponse JSON response with health status and checks.
      */
     public function index(): JSONResponse

--- a/lib/Controller/MetricsController.php
+++ b/lib/Controller/MetricsController.php
@@ -56,6 +56,8 @@ class MetricsController extends Controller
      *
      * @NoCSRFRequired
      *
+     * @spec exclude observability endpoint per ADR-006 (metrics plumbing, no business capability)
+     *
      * @return TextPlainResponse Plain text response with Prometheus metrics.
      */
     public function index(): TextPlainResponse


### PR DESCRIPTION
Adds @spec exclude (ADR-006 plumbing) to HealthController/MetricsController::index added in the Bucket-B work. gate-16 scoped=0.