### PR TITLE
refactor: migrate deprecated IConfig app-values to IAppConfig

### DIFF
--- a/lib/Controller/MetricsController.php
+++ b/lib/Controller/MetricsController.php
@@ -26,6 +26,7 @@ namespace OCA\Planix\Controller;
 use OCA\Planix\AppInfo\Application;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\TextPlainResponse;
+use OCP\IAppConfig;
 use OCP\IConfig;
 use OCP\IRequest;
 
@@ -39,14 +40,16 @@ class MetricsController extends Controller
     /**
      * Constructor for the MetricsController.
      *
-     * @param IRequest $request The request object
-     * @param IConfig  $config  The config service
+     * @param IRequest   $request   The request object
+     * @param IConfig    $config    The config service
+     * @param IAppConfig $appConfig The typed app-config service
      *
      * @return void
      */
     public function __construct(
         IRequest $request,
         private readonly IConfig $config,
+        private readonly IAppConfig $appConfig,
     ) {
         parent::__construct(appName: Application::APP_ID, request: $request);
     }//end __construct()
@@ -64,7 +67,7 @@ class MetricsController extends Controller
     {
         $lines = [];
 
-        $appVersion = $this->config->getAppValue(Application::APP_ID, 'installed_version', '0.0.0');
+        $appVersion = $this->appConfig->getValueString(Application::APP_ID, 'installed_version', '0.0.0');
         $phpVersion = PHP_VERSION;
         $ncVersion  = $this->config->getSystemValueString('version', '0.0.0');
 


### PR DESCRIPTION
## Summary

- Migrates `IConfig::getAppValue` in `MetricsController` to the modern `OCP\IAppConfig::getValueString` typed accessor (NC26+ API)
- Adds `IAppConfig` constructor injection alongside the retained `IConfig` (still required for `getSystemValueString`)
- Behavior-preserving: same key, same default, same return type — no logic changes

## Details

- **File**: `lib/Controller/MetricsController.php`
- **Call migrated**: `$this->config->getAppValue(Application::APP_ID, 'installed_version', '0.0.0')` → `$this->appConfig->getValueString(...)`
- **User-values**: none present in this app
- NC min-version is 28

## Test plan
- [ ] `php -l lib/Controller/MetricsController.php` — no syntax errors
- [ ] Gate-16 spec coverage: exit 0
- [ ] Metrics endpoint returns correct version label in Prometheus output