### PR TITLE
test(e2e): gate-19 e2e-coverage — 0 uncovered (register-schemas whole-spec excluded)

### DIFF
--- a/openspec/specs/register-schemas/spec.md
+++ b/openspec/specs/register-schemas/spec.md
@@ -9,6 +9,8 @@
 
 ## Purpose
 
+<!-- @e2e exclude pure-backend spec: all scenarios concern PHP file content inspection, OpenRegister API validation (HTTP responses), install-time repair steps, and version-skip logic — no browser UI surface exists for any scenario -->
+
 This spec defines the requirements for the Planix OpenRegister schema definitions. The register file declares the data model that all Planix features are built upon. Correct schema definitions, seed data, and import behaviour are prerequisites for every other Planix capability.
 
 ---


### PR DESCRIPTION
Brings planix to Gate-19 e2e-coverage 0 uncovered scenarios. The only spec in openspec/specs/*/spec.md format is register-schemas/spec.md (16 scenarios). All 16 are pure backend (PHP file inspection, OR API validation, install-time behavior, version-skip logic) — whole-spec @e2e exclude applied. Gate-19 PASS: uncovered=0, excluded=16.