### PR TITLE
fix(phpcs): correct equals sign alignment in HealthController

### DIFF
--- a/lib/Controller/HealthController.php
+++ b/lib/Controller/HealthController.php
@@ -76,7 +76,7 @@ class HealthController extends Controller
             $checks['database'] = 'ok';
         } catch (\Exception $e) {
             $checks['database'] = 'error';
-            $status             = 'error';
+            $status = 'error';
             $this->logger->error(
                 'Planix health check: database failed',
                 ['exception' => $e->getMessage()]


### PR DESCRIPTION
Fixes the single PHPCS error in lib/Controller/HealthController.php:79: equals sign alignment (expected 1 space, found 13). Auto-fixed by phpcbf. PHPCS result before: 1 error; after: 0 errors (warnings only, all pre-existing @spec tags).