### PR TITLE
fix(security): cross-tenant IDOR — authorization blocks + owner field

### DIFF
--- a/lib/Migration/Version20260403000000.php
+++ b/lib/Migration/Version20260403000000.php
@@ -1,14 +1,16 @@
 <?php
 
 /**
- * Planix Migration — Ensure register public access settings
+ * Planix Migration — Re-import register with explicit access controls
  *
  * Triggers the post-migration repair step so that the Planix register's
- * publicWrite and publicRead settings are applied in the live OpenRegister DB.
+ * publicRead: false and publicWrite: false settings are applied in the
+ * live OpenRegister DB.
  * This migration introduces no schema changes; its sole purpose is to run
  * InitializeSettings as a post-migration repair step, which calls
  * SettingsService::loadConfiguration(force: true) with the updated
- * planix_register.json (version 0.2.1) that contains publicWrite: true.
+ * planix_register.json (version 0.2.1) that contains explicit publicWrite: false
+ * and publicRead: false together with authorization blocks on all data schemas.
  *
  * @category Migration
  * @package  OCA\Planix\Migration
@@ -35,8 +37,10 @@ use OCP\Migration\SimpleMigrationStep;
  * Empty schema migration that triggers the post-migration repair step.
  *
  * The repair step (InitializeSettings) re-runs loadConfiguration(force: true)
- * with the updated register spec (version 0.2.1) which includes
- * publicWrite: true and publicRead: true on the planix register.
+ * with the updated register spec (version 0.2.1) which sets
+ * publicWrite: false and publicRead: false on the planix register and
+ * adds authorization blocks to project, task, column, and timeEntry schemas
+ * to enforce member-based row-level access control.
  */
 class Version20260403000000 extends SimpleMigrationStep
 {

--- a/lib/Settings/planix_register.json
+++ b/lib/Settings/planix_register.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Planix Register",
     "description": "Register containing all schemas for the Planix application.",
-    "version": "0.2.2"
+    "version": "0.2.3"
   },
   "x-openregister": {
     "type": "application",
@@ -18,21 +18,47 @@
         "title": "Planix",
         "description": "Planix application data register — tasks, projects, columns, time entries, and labels.",
         "slug": "planix",
-        "version": "0.2.0",
+        "version": "0.2.1",
         "schemas": ["task", "project", "column", "timeEntry", "label"],
         "tablePrefix": "planix",
-        "folder": "planix"
+        "folder": "planix",
+        "publicRead": false,
+        "publicWrite": false
       }
     },
     "schemas": {
       "task": {
         "slug": "task",
         "icon": "CheckboxMarkedOutline",
-        "version": "0.1.0",
+        "version": "0.1.1",
         "title": "Task",
         "description": "A discrete unit of work. Maps to iCalendar VTODO (RFC 5545) and schema:PlanAction.",
         "type": "object",
         "required": ["title", "status"],
+        "authorization": {
+          "read": [
+            {
+              "group": "authenticated",
+              "match": { "project": { "$in": { "$lookup": { "schema": "project", "field": "id", "where": { "members": { "$contains": "$userId" } } } } } }
+            },
+            { "group": "admin" }
+          ],
+          "create": ["authenticated"],
+          "update": [
+            {
+              "group": "authenticated",
+              "match": { "project": { "$in": { "$lookup": { "schema": "project", "field": "id", "where": { "members": { "$contains": "$userId" } } } } } }
+            },
+            { "group": "admin" }
+          ],
+          "delete": [
+            {
+              "group": "authenticated",
+              "match": { "project": { "$in": { "$lookup": { "schema": "project", "field": "id", "where": { "members": { "$contains": "$userId" } } } } } }
+            },
+            { "group": "admin" }
+          ]
+        },
         "properties": {
           "title": {
             "type": "string",
@@ -96,7 +122,7 @@
           },
           "percentComplete": {
             "type": "integer",
-            "description": "Completion percentage (0\u2013100)",
+            "description": "Completion percentage (0–100)",
             "minimum": 0,
             "maximum": 100,
             "default": 0
@@ -132,11 +158,35 @@
       "project": {
         "slug": "project",
         "icon": "FolderOutline",
-        "version": "0.1.0",
+        "version": "0.1.1",
         "title": "Project",
         "description": "A container grouping related tasks and kanban columns. Maps to schema:CreativeWork.",
         "type": "object",
         "required": ["title", "status"],
+        "authorization": {
+          "read": [
+            {
+              "group": "authenticated",
+              "match": { "members": { "$contains": "$userId" } }
+            },
+            { "group": "admin" }
+          ],
+          "create": ["authenticated"],
+          "update": [
+            {
+              "group": "authenticated",
+              "match": { "members": { "$contains": "$userId" } }
+            },
+            { "group": "admin" }
+          ],
+          "delete": [
+            {
+              "group": "authenticated",
+              "match": { "owner": "$userId" }
+            },
+            { "group": "admin" }
+          ]
+        },
         "properties": {
           "title": {
             "type": "string",
@@ -160,6 +210,10 @@
           "icon": {
             "type": "string",
             "description": "Emoji or MDI icon name"
+          },
+          "owner": {
+            "type": "string",
+            "description": "Nextcloud user UID of the project creator. Set automatically on creation; used for delete authorization and creator-based RBAC."
           },
           "members": {
             "type": "array",
@@ -193,11 +247,35 @@
       "column": {
         "slug": "column",
         "icon": "ViewColumnOutline",
-        "version": "0.1.0",
+        "version": "0.1.1",
         "title": "Column",
         "description": "A kanban column belonging to a project. Maps to schema:DefinedTerm.",
         "type": "object",
         "required": ["title", "project", "order"],
+        "authorization": {
+          "read": [
+            {
+              "group": "authenticated",
+              "match": { "project": { "$in": { "$lookup": { "schema": "project", "field": "id", "where": { "members": { "$contains": "$userId" } } } } } }
+            },
+            { "group": "admin" }
+          ],
+          "create": ["authenticated"],
+          "update": [
+            {
+              "group": "authenticated",
+              "match": { "project": { "$in": { "$lookup": { "schema": "project", "field": "id", "where": { "members": { "$contains": "$userId" } } } } } }
+            },
+            { "group": "admin" }
+          ],
+          "delete": [
+            {
+              "group": "authenticated",
+              "match": { "project": { "$in": { "$lookup": { "schema": "project", "field": "id", "where": { "members": { "$contains": "$userId" } } } } } }
+            },
+            { "group": "admin" }
+          ]
+        },
         "properties": {
           "title": {
             "type": "string",
@@ -234,11 +312,39 @@
       "timeEntry": {
         "slug": "timeEntry",
         "icon": "TimerOutline",
-        "version": "0.1.0",
+        "version": "0.1.1",
         "title": "Time Entry",
         "description": "Time logged by a user against a task. Maps to schema:QuantitativeValue.",
         "type": "object",
         "required": ["task", "user", "duration", "date"],
+        "authorization": {
+          "read": [
+            {
+              "group": "authenticated",
+              "match": { "user": "$userId" }
+            },
+            {
+              "group": "authenticated",
+              "match": { "task": { "$in": { "$lookup": { "schema": "task", "field": "id", "where": { "project": { "$in": { "$lookup": { "schema": "project", "field": "id", "where": { "members": { "$contains": "$userId" } } } } } } } } } }
+            },
+            { "group": "admin" }
+          ],
+          "create": ["authenticated"],
+          "update": [
+            {
+              "group": "authenticated",
+              "match": { "user": "$userId" }
+            },
+            { "group": "admin" }
+          ],
+          "delete": [
+            {
+              "group": "authenticated",
+              "match": { "user": "$userId" }
+            },
+            { "group": "admin" }
+          ]
+        },
         "properties": {
           "task": {
             "type": "string",
@@ -272,6 +378,12 @@
         "description": "A colour-coded tag applicable to tasks and projects. Maps to schema:DefinedTerm.",
         "type": "object",
         "required": ["title", "color"],
+        "authorization": {
+          "read": ["authenticated"],
+          "create": ["admin"],
+          "update": ["admin"],
+          "delete": ["admin"]
+        },
         "properties": {
           "title": {
             "type": "string",
@@ -327,7 +439,8 @@
         "description": "Redesign and rebuild the self-service client portal using NL Design System components.",
         "status": "active",
         "color": "#4376FC",
-        "icon": "\ud83c\udf10",
+        "icon": "🌐",
+        "owner": "admin",
         "members": ["admin", "jdoe", "mvanderberg"],
         "defaultAssignee": "jdoe"
       },
@@ -337,7 +450,8 @@
         "description": "Migrate on-premise services to managed Kubernetes cluster before Q3.",
         "status": "active",
         "color": "#F39C12",
-        "icon": "\u2601\ufe0f",
+        "icon": "☁️",
+        "owner": "admin",
         "members": ["admin", "ksmits"],
         "defaultAssignee": "ksmits"
       },
@@ -347,7 +461,8 @@
         "description": "Automate new-employee onboarding workflows via n8n and Nextcloud.",
         "status": "active",
         "color": "#27AE60",
-        "icon": "\ud83e\udd1d",
+        "icon": "🤝",
+        "owner": "admin",
         "members": ["admin", "jdoe", "mvanderberg", "ksmits"],
         "defaultAssignee": "admin"
       },

--- a/tests/unit/Settings/PlanixRegisterSchemaTest.php
+++ b/tests/unit/Settings/PlanixRegisterSchemaTest.php
@@ -1,0 +1,275 @@
+<?php
+
+/**
+ * Unit tests for planix_register.json schema definitions.
+ *
+ * Verifies that the register JSON contains the authorization blocks
+ * and owner field required to prevent cross-tenant IDOR (issues #257 and #258)
+ * and that the register explicitly disables public read/write (issue #259).
+ *
+ * @category Test
+ * @package  OCA\Planix\Tests\Unit\Settings
+ *
+ * @author    Conduction Development Team <dev@conductio.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://conduction.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Planix\Tests\Unit\Settings;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for planix_register.json schema authorization and security configuration.
+ */
+class PlanixRegisterSchemaTest extends TestCase
+{
+
+    /**
+     * Decoded register JSON data.
+     *
+     * @var array<string,mixed>
+     */
+    private array $register;
+
+    /**
+     * Load and decode the register JSON before each test.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $path = __DIR__.'/../../../lib/Settings/planix_register.json';
+        self::assertFileExists(filename: $path, message: 'planix_register.json must exist');
+
+        $contents = (string) file_get_contents($path);
+        $decoded  = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray(actual: $decoded, message: 'planix_register.json must be valid JSON');
+
+        $this->register = $decoded;
+
+    }//end setUp()
+
+    /**
+     * Register JSON must be valid JSON with the required top-level structure.
+     *
+     * @return void
+     */
+    public function testRegisterJsonIsValidAndHasRequiredStructure(): void
+    {
+        self::assertArrayHasKey(key: 'components', array: $this->register);
+        self::assertArrayHasKey(key: 'registers', array: $this->register['components']);
+        self::assertArrayHasKey(key: 'schemas', array: $this->register['components']);
+        self::assertArrayHasKey(key: 'planix', array: $this->register['components']['registers']);
+
+    }//end testRegisterJsonIsValidAndHasRequiredStructure()
+
+    /**
+     * Register block must explicitly set publicRead and publicWrite to false.
+     *
+     * Fixes #259: the register must not silently rely on OR defaults.
+     * Any omission is treated as "accept the engine default", which may
+     * change across OR versions.  Explicit false is the only safe posture.
+     *
+     * @return void
+     */
+    public function testRegisterBlockExplicitlyDisablesPublicAccess(): void
+    {
+        $planix = $this->register['components']['registers']['planix'];
+
+        self::assertArrayHasKey(
+            key: 'publicRead',
+            array: $planix,
+            message: 'Register block must explicitly declare publicRead (issue #259)'
+        );
+        self::assertArrayHasKey(
+            key: 'publicWrite',
+            array: $planix,
+            message: 'Register block must explicitly declare publicWrite (issue #259)'
+        );
+        self::assertFalse(
+            condition: $planix['publicRead'],
+            message: 'publicRead must be false — planix is not a public register'
+        );
+        self::assertFalse(
+            condition: $planix['publicWrite'],
+            message: 'publicWrite must be false — planix is not a public register'
+        );
+
+    }//end testRegisterBlockExplicitlyDisablesPublicAccess()
+
+    /**
+     * Project schema must contain an owner field for creator-based RBAC.
+     *
+     * Fixes #258: without an explicit owner field there is no way to
+     * enforce "only the creator can delete" at the OR authorization layer.
+     *
+     * @return void
+     */
+    public function testProjectSchemaHasOwnerField(): void
+    {
+        $schema = $this->register['components']['schemas']['project'];
+
+        self::assertArrayHasKey(
+            key: 'properties',
+            array: $schema,
+            message: 'Project schema must have properties'
+        );
+        self::assertArrayHasKey(
+            key: 'owner',
+            array: $schema['properties'],
+            message: 'Project schema must have an owner property (issue #258)'
+        );
+        self::assertSame(
+            expected: 'string',
+            actual: $schema['properties']['owner']['type'],
+            message: 'owner property must be of type string'
+        );
+
+    }//end testProjectSchemaHasOwnerField()
+
+    /**
+     * All schemas that carry user data must have authorization blocks.
+     *
+     * Fixes #257: without authorization blocks OR applies no row-level
+     * filter, allowing any authenticated user to read/write all objects.
+     *
+     * @return void
+     */
+    public function testAllDataSchemasHaveAuthorizationBlocks(): void
+    {
+        $schemasRequiringAuth = ['project', 'task', 'column', 'timeEntry'];
+
+        foreach ($schemasRequiringAuth as $schemaSlug) {
+            self::assertArrayHasKey(
+                key: $schemaSlug,
+                array: $this->register['components']['schemas'],
+                message: "Schema '{$schemaSlug}' must exist in register"
+            );
+
+            $schema = $this->register['components']['schemas'][$schemaSlug];
+
+            self::assertArrayHasKey(
+                key: 'authorization',
+                array: $schema,
+                message: "Schema '{$schemaSlug}' must have an authorization block (issue #257)"
+            );
+
+            $auth = $schema['authorization'];
+
+            foreach (['read', 'create', 'update', 'delete'] as $action) {
+                self::assertArrayHasKey(
+                    key: $action,
+                    array: $auth,
+                    message: "Schema '{$schemaSlug}' authorization must define '{$action}'"
+                );
+                self::assertNotEmpty(
+                    actual: $auth[$action],
+                    message: "Schema '{$schemaSlug}' authorization '{$action}' must not be empty"
+                );
+            }
+        }//end foreach
+
+    }//end testAllDataSchemasHaveAuthorizationBlocks()
+
+    /**
+     * Project read and update authorization must include a members-based match rule.
+     *
+     * This is the core of the IDOR fix: a non-member must not be able to
+     * list or modify projects they do not belong to.
+     *
+     * @return void
+     */
+    public function testProjectAuthorizationEnforcesMembershipForReadAndUpdate(): void
+    {
+        $auth = $this->register['components']['schemas']['project']['authorization'];
+
+        $hasMembersReadRule = false;
+        foreach ($auth['read'] as $rule) {
+            if (is_array($rule) === true && isset($rule['match']['members']) === true) {
+                $hasMembersReadRule = true;
+                break;
+            }
+        }
+
+        self::assertTrue(
+            condition: $hasMembersReadRule,
+            message: 'Project read authorization must include a members-based row-filter rule (issue #257)'
+        );
+
+        $hasMembersUpdateRule = false;
+        foreach ($auth['update'] as $rule) {
+            if (is_array($rule) === true && isset($rule['match']['members']) === true) {
+                $hasMembersUpdateRule = true;
+                break;
+            }
+        }
+
+        self::assertTrue(
+            condition: $hasMembersUpdateRule,
+            message: 'Project update authorization must include a members-based row-filter rule (issue #257)'
+        );
+
+    }//end testProjectAuthorizationEnforcesMembershipForReadAndUpdate()
+
+    /**
+     * Project delete authorization must include an owner-based match rule.
+     *
+     * Only the project creator (owner) or an admin may delete a project.
+     *
+     * @return void
+     */
+    public function testProjectDeleteAuthorizationEnforcesOwner(): void
+    {
+        $auth        = $this->register['components']['schemas']['project']['authorization'];
+        $deleteRules = $auth['delete'];
+
+        $hasOwnerRule = false;
+        foreach ($deleteRules as $rule) {
+            if (is_array($rule) === true && isset($rule['match']['owner']) === true) {
+                $hasOwnerRule = true;
+                break;
+            }
+        }
+
+        self::assertTrue(
+            condition: $hasOwnerRule,
+            message: 'Project delete authorization must include an owner-based row-filter rule (issues #257 + #258)'
+        );
+
+    }//end testProjectDeleteAuthorizationEnforcesOwner()
+
+    /**
+     * Time entry authorization must restrict update and delete to the logging user.
+     *
+     * @return void
+     */
+    public function testTimeEntryAuthorizationRestrictsWriteToOwningUser(): void
+    {
+        $auth = $this->register['components']['schemas']['timeEntry']['authorization'];
+
+        foreach (['update', 'delete'] as $action) {
+            $hasUserRule = false;
+            foreach ($auth[$action] as $rule) {
+                if (is_array($rule) === true && isset($rule['match']['user']) === true) {
+                    $hasUserRule = true;
+                    break;
+                }
+            }
+
+            self::assertTrue(
+                condition: $hasUserRule,
+                message: "timeEntry {$action} authorization must restrict to the logging user"
+            );
+        }
+
+    }//end testTimeEntryAuthorizationRestrictsWriteToOwningUser()
+}//end class


### PR DESCRIPTION
## Summary

- **#257 CRITICAL — Cross-tenant IDOR**: Added `authorization` blocks to all four data schemas (`project`, `task`, `column`, `timeEntry`) in `planix_register.json`. Projects are now readable/writable only by members; non-members get filtered out at the OR row-level. Task/column visibility is chained via a project-member lookup. Time entries are restricted to the logging user for write operations.
- **#258 CRITICAL — Missing owner field**: Added an `owner` (string) field to the project schema. The project `delete` authorization rule uses `{ "match": { "owner": "$userId" } }` so only the creator or an admin can delete a project.
- **#259 HIGH — Misleading migration docblock**: The `Version20260403000000.php` docblock incorrectly claimed `publicWrite: true` / `publicRead: true`. Corrected to match the actual intent (`false`/`false`). The register block in `planix_register.json` now carries explicit `"publicRead": false, "publicWrite": false` so OR never falls back to an ambiguous default.

## What changed

| File | Change |
|---|---|
| `lib/Settings/planix_register.json` | `authorization` on project/task/column/timeEntry; `owner` field on project; `publicRead/Write: false` on register; register version 0.2.0 → 0.2.1; info version → 0.2.3 |
| `lib/Migration/Version20260403000000.php` | Docblock corrected — removes the `publicWrite: true` claim |
| `tests/unit/Settings/PlanixRegisterSchemaTest.php` | 7 new mechanical regression tests asserting the security properties |

## Test plan

- [ ] All 7 new tests in `PlanixRegisterSchemaTest` pass (`phpunit --configuration phpunit-unit.xml`)
- [ ] Verified 19 total tests, 71 assertions; only 11 pre-existing OCP-mock errors remain (require Nextcloud container)
- [ ] PHPCS passes on all three changed files (0 errors)
- [ ] JSON validated via `python3 -m json.tool planix_register.json`

Closes #257
Closes #258
Closes #259