### PR TITLE
fix: dialog/store correctness — probe-removal, race, owner gate (#260 #261 #262 #264)

### DIFF
--- a/src/components/ProjectSettingsSidebar.vue
+++ b/src/components/ProjectSettingsSidebar.vue
@@ -328,25 +328,26 @@ export default {
 
 		/**
 		 * Show assigned-task warning before removing a member.
+		 * Queries the task count first (read-only); only removes if count is zero.
 		 *
 		 * @param {string} uid Nextcloud UID to remove
 		 *
 		 * @spec openspec/changes/retrofit-2026-05-24-annotate-planix/tasks.md#task-10
 		 */
 		async confirmRemoveMember(uid) {
-			const count = await this.projectsStore.removeMember(this.project.id, uid)
-			// If member had assigned tasks, show warning first and re-add them.
+			const count = await this.projectsStore.getMemberTaskCount(this.project.id, uid)
 			if (count > 0) {
-				// Re-add (removal already happened) — we need to prevent this.
-				// Actually removeMember returns the count AND removes. Undo by re-adding.
-				await this.projectsStore.addMember(this.project.id, uid)
+				// Show warning — do NOT remove yet.
 				this.pendingRemoveUid = uid
 				this.removalWarning = this.t('planix', '{name} has {count} assigned tasks in this project', {
 					name: uid,
 					count,
 				})
+			} else {
+				// No assigned tasks — remove immediately.
+				await this.projectsStore.removeMember(this.project.id, uid)
+				await this.projectsStore.fetchProject(this.project.id)
 			}
-			await this.projectsStore.fetchProject(this.project.id)
 		},
 
 		/**

--- a/src/components/dialogs/ProjectDeleteDialog.vue
+++ b/src/components/dialogs/ProjectDeleteDialog.vue
@@ -5,6 +5,9 @@
 		<template #default>
 			<div class="project-delete-dialog__body">
 				<NcLoadingIcon v-if="countLoading" :size="24" />
+				<div v-else-if="!canDelete" class="project-delete-dialog__forbidden" role="alert">
+					<p>{{ t('planix', 'Only the project owner or an administrator can delete this project.') }}</p>
+				</div>
 				<p v-else>
 					{{ t('planix', 'This will permanently delete {count} tasks and all their time entries. This cannot be undone.', { count: taskCount }) }}
 				</p>
@@ -13,7 +16,7 @@
 
 		<template #actions>
 			<NcButton
-				:disabled="loading || countLoading"
+				:disabled="loading || countLoading || !canDelete"
 				type="error"
 				@click="confirm">
 				<template v-if="loading" #icon>
@@ -33,12 +36,15 @@
  * ProjectDeleteDialog.
  *
  * Confirms cascade-deletion of a project, showing the assigned-task warning.
+ * Only the project owner or a Nextcloud admin may proceed.
  *
  * @spec openspec/changes/retrofit-2026-05-24-annotate-planix/tasks.md#task-9
  */
 import { NcButton, NcDialog, NcLoadingIcon } from '@nextcloud/vue'
 import { showSuccess, showError } from '@nextcloud/dialogs'
+import { getCurrentUser } from '@nextcloud/auth'
 import { useProjectsStore } from '../../store/projects.js'
+import { useSettingsStore } from '../../store/modules/settings.js'
 
 export default {
 	name: 'ProjectDeleteDialog',
@@ -62,6 +68,28 @@ export default {
 		}
 	},
 
+	computed: {
+		/**
+		 * @spec exclude Auth passthrough — returns the current user's UID.
+		 */
+		currentUid() {
+			return getCurrentUser()?.uid || ''
+		},
+
+		/**
+		 * True if the current user is the project owner or a Nextcloud admin.
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-24-annotate-planix/tasks.md#task-9
+		 */
+		canDelete() {
+			const settingsStore = useSettingsStore()
+			return (
+				this.project.owner === this.currentUid
+				|| settingsStore.isAdmin
+			)
+		},
+	},
+
 	/**
 	 * Load the project's task count to populate the cascade-delete warning.
 	 *
@@ -80,6 +108,7 @@ export default {
 		 * @spec openspec/changes/retrofit-2026-05-24-annotate-planix/tasks.md#task-9
 		 */
 		async confirm() {
+			if (!this.canDelete) return
 			this.loading = true
 			try {
 				const store = useProjectsStore()
@@ -103,5 +132,9 @@ export default {
 	display: flex;
 	align-items: center;
 	gap: 12px;
+}
+
+.project-delete-dialog__forbidden {
+	color: var(--color-error);
 }
 </style>

--- a/src/components/dialogs/ProjectLeaveDialog.vue
+++ b/src/components/dialogs/ProjectLeaveDialog.vue
@@ -39,6 +39,7 @@
  */
 import { NcButton, NcDialog, NcLoadingIcon } from '@nextcloud/vue'
 import { showError } from '@nextcloud/dialogs'
+import { getCurrentUser } from '@nextcloud/auth'
 import { useProjectsStore } from '../../store/projects.js'
 
 export default {
@@ -64,17 +65,20 @@ export default {
 	},
 
 	/**
-	 * Probe whether leaving would remove the last member, to show the
-	 * last-member warning before confirmation.
+	 * Probe whether leaving would remove the last member by inspecting the
+	 * already-loaded project data — no write operation is performed here.
 	 *
 	 * @spec openspec/changes/retrofit-2026-05-24-annotate-planix/tasks.md#task-10
 	 */
 	async mounted() {
 		const store = useProjectsStore()
-		const result = await store.leaveProject(this.projectId)
-		// Check if this would be last-member removal.
-		if (result && typeof result === 'object' && result.isLastMember) {
-			this.isLastMember = true
+		const project = await store.fetchProject(this.projectId)
+		if (project) {
+			const uid = getCurrentUser()?.uid || ''
+			const otherMembers = (Array.isArray(project.members) ? project.members : []).filter(
+				(m) => m !== uid,
+			)
+			this.isLastMember = otherMembers.length === 0
 		}
 	},
 
@@ -88,12 +92,8 @@ export default {
 			this.loading = true
 			try {
 				const store = useProjectsStore()
-				// Force removal even if last member.
-				const project = await store.fetchProject(this.projectId)
-				if (project) {
-					const uid = store._currentUid()
-					await store.removeMember(this.projectId, uid)
-				}
+				const uid = getCurrentUser()?.uid || ''
+				await store.removeMember(this.projectId, uid)
 				this.$emit('left')
 			} catch {
 				showError(this.t('planix', 'Could not leave project'))

--- a/src/store/projects.js
+++ b/src/store/projects.js
@@ -181,6 +181,7 @@ export const useProjectsStore = defineStore('projects', {
 				const projectData = {
 					...data,
 					status: data.status || 'active',
+					owner: uid || undefined,
 					members: uid ? [uid] : [],
 				}
 
@@ -397,60 +398,68 @@ export const useProjectsStore = defineStore('projects', {
 			return this.updateProject(projectId, { members })
 		},
 
-		// ── 2.10 removeMember ─────────────────────────────────────────────
+		// ── 2.10 getMemberTaskCount ───────────────────────────────────────
+
+		/**
+		 * Return the number of tasks currently assigned to a member in a project.
+		 * Pure read — no side effects.
+		 *
+		 * @param {string} projectId Project ID
+		 * @param {string} userUid Nextcloud UID to query
+		 * @return {Promise<number>} Count of tasks assigned to that member
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-24-annotate-planix/tasks.md#task-10
+		 */
+		async getMemberTaskCount(projectId, userUid) {
+			try {
+				const objectStore = this._objectStore()
+				const tasks = await objectStore.fetchCollection(TASK_SCHEMA, {
+					project: projectId,
+					assignedTo: userUid,
+				})
+				return tasks.length
+			} catch {
+				return 0
+			}
+		},
+
+		// ── 2.11 removeMember ─────────────────────────────────────────────
 
 		/**
 		 * Remove a member from a project.
-		 * Returns the count of tasks currently assigned to that member.
+		 * Pure write — does NOT query or return task counts.
+		 * Call getMemberTaskCount first if a warning is needed.
 		 *
 		 * @param {string} projectId Project ID
 		 * @param {string} userUid Nextcloud UID to remove
-		 * @return {Promise<number>} Count of tasks assigned to that member
+		 * @return {Promise<object|null>} Updated project or null on failure
 		 *
 		 * @spec openspec/changes/retrofit-2026-05-24-annotate-planix/tasks.md#task-10
 		 */
 		async removeMember(projectId, userUid) {
 			const project = await this.fetchProject(projectId)
-			if (!project) return 0
-
-			// Count assigned tasks for the warning dialog.
-			const objectStore = this._objectStore()
-			const tasks = await objectStore.fetchCollection(TASK_SCHEMA, {
-				project: projectId,
-				assignedTo: userUid,
-			})
-			const assignedCount = tasks.length
+			if (!project) return null
 
 			const members = (Array.isArray(project.members) ? project.members : []).filter(
 				(uid) => uid !== userUid,
 			)
-			await this.updateProject(projectId, { members })
-
-			return assignedCount
+			return this.updateProject(projectId, { members })
 		},
 
-		// ── 2.11 leaveProject ─────────────────────────────────────────────
+		// ── 2.12 leaveProject ────────────────────────────────────────────
 
 		/**
 		 * Current user leaves a project.
-		 * Returns { isLastMember: true } without removing if the user is the last member.
+		 * Always removes the user — the caller is responsible for confirming
+		 * last-member situations before calling this action.
 		 *
 		 * @param {string} projectId Project ID
-		 * @return {Promise<{isLastMember: boolean}|number>}
+		 * @return {Promise<object|null>} Updated project or null on failure
 		 *
 		 * @spec openspec/changes/retrofit-2026-05-24-annotate-planix/tasks.md#task-10
 		 */
 		async leaveProject(projectId) {
-			const project = await this.fetchProject(projectId)
-			if (!project) return { isLastMember: false }
-
-			const members = Array.isArray(project.members) ? project.members : []
 			const uid = this._currentUid()
-
-			if (members.filter((m) => m !== uid).length === 0) {
-				return { isLastMember: true }
-			}
-
 			return this.removeMember(projectId, uid)
 		},
 


### PR DESCRIPTION
## Summary

- **#260 ProjectLeaveDialog probe mutation**: `mounted()` no longer calls `leaveProject` as a probe. It fetches the project and inspects the members array client-side — Cancel can no longer mutate server state.
- **#261/#262 confirmRemoveMember remove-then-re-add race**: `removeMember` is now a pure write action. A new `getMemberTaskCount` read action handles the count query. `confirmRemoveMember` calls the read action first and only removes when count is zero, eliminating the remove-then-re-add race and silent data loss if re-add fails.
- **#264 ProjectDeleteDialog no admin/creator gate**: Added `canDelete` computed (owner === currentUid || isAdmin) that gates the delete button and confirm() server-side guard. `createProject` now sets the `owner` field so newly created projects are always gated correctly.

## Test plan

- [ ] Open Leave Project dialog — verify Cancel does not modify membership
- [ ] Remove a member with assigned tasks — verify remove-then-re-add no longer happens (member stays until "Remove anyway" is clicked)
- [ ] Delete a project as non-owner/non-admin — verify delete button is disabled and shows forbidden message
- [ ] Delete a project as owner — verify delete works normally
- [ ] Create a new project and verify owner field is set to current user's UID