### PR TITLE
fix: cascade error messages, settings validation, deep links, creation policy (#263 #265 #266 #267)

### DIFF
--- a/lib/Listener/DeepLinkRegistrationListener.php
+++ b/lib/Listener/DeepLinkRegistrationListener.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace OCA\Planix\Listener;
 
 use OCA\OpenRegister\Event\DeepLinkRegistrationEvent;
+use OCA\Planix\AppInfo\Application;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 
@@ -32,6 +33,11 @@ use OCP\EventDispatcher\IEventListener;
  *
  * When a user searches in Nextcloud's unified search, results for Planix schemas
  * will link directly to the relevant detail views in the app.
+ *
+ * URL templates use history-mode paths (no leading #) to match the Vue Router
+ * configuration in src/router/index.js (mode: 'history', base: /apps/planix).
+ * Tasks and projects have dedicated routes; columns, labels, and time entries
+ * route to their parent project board since there are no standalone detail views.
  *
  * @implements IEventListener<Event>
  */
@@ -52,39 +58,44 @@ class DeepLinkRegistrationListener implements IEventListener
             return;
         }
 
+        // Tasks link to the project board filtered by task UUID.
         $event->register(
-            appId: 'planix',
-            registerSlug: 'planix',
+            appId: Application::APP_ID,
+            registerSlug: Application::APP_ID,
             schemaSlug: 'task',
-            urlTemplate: '/apps/planix/#/tasks/{uuid}'
+            urlTemplate: '/apps/'.Application::APP_ID.'/projects/{project}?task={uuid}'
         );
 
+        // Projects link directly to the project board.
         $event->register(
-            appId: 'planix',
-            registerSlug: 'planix',
+            appId: Application::APP_ID,
+            registerSlug: Application::APP_ID,
             schemaSlug: 'project',
-            urlTemplate: '/apps/planix/#/projects/{uuid}'
+            urlTemplate: '/apps/'.Application::APP_ID.'/projects/{uuid}'
         );
 
+        // Columns have no standalone route — route to the parent project board.
         $event->register(
-            appId: 'planix',
-            registerSlug: 'planix',
+            appId: Application::APP_ID,
+            registerSlug: Application::APP_ID,
             schemaSlug: 'column',
-            urlTemplate: '/apps/planix/#/columns/{uuid}'
+            urlTemplate: '/apps/'.Application::APP_ID.'/projects/{project}'
         );
 
+        // Labels have no standalone route — fall back to the project list.
         $event->register(
-            appId: 'planix',
-            registerSlug: 'planix',
+            appId: Application::APP_ID,
+            registerSlug: Application::APP_ID,
             schemaSlug: 'label',
-            urlTemplate: '/apps/planix/#/labels/{uuid}'
+            urlTemplate: '/apps/'.Application::APP_ID.'/projects'
         );
 
+        // Time entries have no standalone route — route to the task's project board.
         $event->register(
-            appId: 'planix',
-            registerSlug: 'planix',
+            appId: Application::APP_ID,
+            registerSlug: Application::APP_ID,
             schemaSlug: 'timeEntry',
-            urlTemplate: '/apps/planix/#/time-entries/{uuid}'
+            urlTemplate: '/apps/'.Application::APP_ID.'/projects/{project}?task={task}'
         );
 
     }//end handle()

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -128,7 +128,44 @@ class SettingsService
     }//end getAdminSettings()
 
     /**
+     * Validate the default_columns value before persisting.
+     *
+     * Must be a non-empty JSON array of non-empty strings. Returns a normalised
+     * JSON string on success or null when validation fails (caller should reject).
+     *
+     * @param string $raw Raw value submitted by the client
+     *
+     * @return string|null Normalised JSON string, or null on validation failure
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-annotate-planix/tasks.md#task-4
+     */
+    public function validateDefaultColumns(string $raw): ?string
+    {
+        $decoded = json_decode($raw, true);
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            return null;
+        }
+
+        if (is_array($decoded) === false || count($decoded) === 0) {
+            return null;
+        }
+
+        $normalised = [];
+        foreach ($decoded as $item) {
+            if (is_string($item) === false || trim($item) === '') {
+                return null;
+            }
+
+            $normalised[] = trim($item);
+        }
+
+        return json_encode($normalised);
+
+    }//end validateDefaultColumns()
+
+    /**
      * Store admin settings. Unknown keys are silently ignored.
+     * Validates default_columns JSON shape before persisting; rejects malformed values.
      *
      * Internal use only — callers outside this class must go through updateSettings(),
      * which enforces the admin authorization check at the controller layer.
@@ -142,10 +179,28 @@ class SettingsService
     private function setAdminSettings(array $settings): void
     {
         foreach (array_keys(self::ADMIN_CONFIG_DEFAULTS) as $key) {
-            if (array_key_exists($key, $settings) === true) {
-                $this->appConfig->setValueString(Application::APP_ID, $key, (string) $settings[$key]);
+            if (array_key_exists($key, $settings) === false) {
+                continue;
             }
-        }
+
+            $value = (string) $settings[$key];
+
+            if ($key === 'default_columns') {
+                $validated = $this->validateDefaultColumns($value);
+                if ($validated === null) {
+                    $this->logger->warning(
+                        'Planix: invalid default_columns value rejected',
+                        ['raw' => $value]
+                    );
+                    continue;
+                }
+
+                $value = $validated;
+            }
+
+            $this->appConfig->setValueString(Application::APP_ID, $key, $value);
+        }//end foreach
+
     }//end setAdminSettings()
 
     /**

--- a/src/store/projects.js
+++ b/src/store/projects.js
@@ -323,12 +323,15 @@ export const useProjectsStore = defineStore('projects', {
 				const tasks = await objectStore.fetchCollection(TASK_SCHEMA, { project: id })
 
 				// 2. Fetch and delete time entries for each task.
+				// NOTE: deletion is sequential and non-transactional. A mid-flight failure
+				// (network drop, server error) will leave orphaned objects. The error messages
+				// below prompt the user to retry, which will pick up where deletion failed.
 				for (const task of tasks) {
 					const entries = await objectStore.fetchCollection(TIME_ENTRY_SCHEMA, { task: task.id })
 					for (const entry of entries) {
 						const ok = await objectStore.deleteObject(TIME_ENTRY_SCHEMA, entry.id)
 						if (!ok) {
-							showError(t('planix', 'Failed to delete time entry — deletion stopped'))
+							showError(t('planix', 'Failed to delete a time entry. Some data may remain — please retry deleting the project.'))
 							return false
 						}
 					}
@@ -338,7 +341,7 @@ export const useProjectsStore = defineStore('projects', {
 				for (const task of tasks) {
 					const ok = await objectStore.deleteObject(TASK_SCHEMA, task.id)
 					if (!ok) {
-						showError(t('planix', 'Failed to delete task — deletion stopped'))
+						showError(t('planix', 'Failed to delete a task. Some data may remain — please retry deleting the project.'))
 						return false
 					}
 				}
@@ -348,7 +351,7 @@ export const useProjectsStore = defineStore('projects', {
 				for (const col of columns) {
 					const ok = await objectStore.deleteObject(COLUMN_SCHEMA, col.id)
 					if (!ok) {
-						showError(t('planix', 'Failed to delete column — deletion stopped'))
+						showError(t('planix', 'Failed to delete a column. Some data may remain — please retry deleting the project.'))
 						return false
 					}
 				}
@@ -356,7 +359,7 @@ export const useProjectsStore = defineStore('projects', {
 				// 5. Delete the project itself.
 				const ok = await objectStore.deleteObject(PROJECT_SCHEMA, id)
 				if (!ok) {
-					showError(t('planix', 'Failed to delete project'))
+					showError(t('planix', 'Failed to delete project. Please retry.'))
 					return false
 				}
 

--- a/src/views/ProjectList.vue
+++ b/src/views/ProjectList.vue
@@ -15,8 +15,9 @@
 					:no-close="true"
 					:aria-pressed="activeStatus === chip.value"
 					@click="setStatusFilter(chip.value)" />
-				<!-- New project button -->
+				<!-- New project button — hidden when creation is restricted to admins -->
 				<NcButton
+					v-if="canCreateProject"
 					type="primary"
 					@click="showCreationDialog = true">
 					<template #icon>
@@ -60,11 +61,11 @@
 		<NcEmptyContent
 			v-else-if="projects.length === 0"
 			:name="t('planix', 'No projects yet')"
-			:description="t('planix', 'Create your first project to get started.')">
+			:description="canCreateProject ? t('planix', 'Create your first project to get started.') : t('planix', 'No projects are available to you yet. Ask an administrator to create one.')">
 			<template #icon>
 				<FolderOutline :size="20" />
 			</template>
-			<template #action>
+			<template v-if="canCreateProject" #action>
 				<NcButton type="primary" @click="showCreationDialog = true">
 					{{ t('planix', 'Create your first project') }}
 				</NcButton>
@@ -90,9 +91,9 @@
 				@click="navigateToProject(project)" />
 		</ul>
 
-		<!-- Creation dialog -->
+		<!-- Creation dialog — only mounted when creation is permitted -->
 		<ProjectCreationDialog
-			v-if="showCreationDialog"
+			v-if="showCreationDialog && canCreateProject"
 			@close="showCreationDialog = false"
 			@created="onProjectCreated" />
 	</div>
@@ -116,6 +117,7 @@ import Magnify from 'vue-material-design-icons/Magnify.vue'
 import PlusIcon from 'vue-material-design-icons/Plus.vue'
 
 import { useProjectsStore } from '../store/projects.js'
+import { useSettingsStore } from '../store/modules/settings.js'
 import ProjectListItem from '../components/ProjectListItem.vue'
 import ProjectCreationDialog from '../components/dialogs/ProjectCreationDialog.vue'
 
@@ -178,6 +180,25 @@ export default {
 		 */
 		error() {
 			return this.projectsStore.error
+		},
+
+		/**
+		 * Returns true when the current user is allowed to create new projects.
+		 * Reads allow_project_creation: 'all' (default) | 'admins'.
+		 * Any unrecognised value defaults to allowing all authenticated users.
+		 *
+		 * @return {boolean}
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-24-annotate-planix/tasks.md#task-12
+		 */
+		canCreateProject() {
+			const settingsStore = useSettingsStore()
+			const policy = settingsStore.settings?.allow_project_creation || 'all'
+			if (policy === 'admins') {
+				return !!settingsStore.isAdmin
+			}
+			// 'all' or any unrecognised value — every authenticated user may create.
+			return true
 		},
 
 		/**

--- a/src/views/settings/Settings.vue
+++ b/src/views/settings/Settings.vue
@@ -59,6 +59,40 @@
 			</form>
 		</CnSettingsSection>
 
+		<!-- Project creation policy -->
+		<CnSettingsSection
+			:name="t('planix', 'Project creation')"
+			:description="t('planix', 'Control who may create new projects')">
+			<form @submit.prevent="saveCreationPolicy">
+				<div class="form-group">
+					<label for="allow-project-creation">{{ t('planix', 'Allow project creation') }}</label>
+					<select
+						id="allow-project-creation"
+						v-model="creationPolicy"
+						class="column-input">
+						<option value="all">
+							{{ t('planix', 'All authenticated users') }}
+						</option>
+						<option value="admins">
+							{{ t('planix', 'Administrators only') }}
+						</option>
+					</select>
+				</div>
+				<div v-if="creationPolicySuccess" class="success-message">
+					{{ creationPolicySuccess }}
+				</div>
+				<div v-if="creationPolicyError" class="error-message">
+					{{ creationPolicyError }}
+				</div>
+				<NcButton
+					type="primary"
+					native-type="submit"
+					:disabled="savingCreationPolicy">
+					{{ savingCreationPolicy ? t('planix', 'Saving...') : t('planix', 'Save') }}
+				</NcButton>
+			</form>
+		</CnSettingsSection>
+
 		<!-- Register setup -->
 		<CnSettingsSection
 			:name="t('planix', 'Register setup')"
@@ -154,6 +188,11 @@ export default {
 			initializing: false,
 			initSuccess: '',
 			initError: '',
+			// allow_project_creation
+			creationPolicy: 'all',
+			savingCreationPolicy: false,
+			creationPolicySuccess: '',
+			creationPolicyError: '',
 		}
 	},
 	computed: {
@@ -170,6 +209,7 @@ export default {
 	created() {
 		const settingsStore = useSettingsStore()
 		this.form.register = settingsStore.settings?.register || ''
+		this.creationPolicy = settingsStore.settings?.allow_project_creation || 'all'
 		this.loadColumnList(settingsStore.settings)
 	},
 	methods: {
@@ -244,6 +284,27 @@ export default {
 			}
 			this.savingColumns = false
 		},
+		/**
+		 * Persist the project creation policy via settingsStore.saveSettings.
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-24-annotate-planix/tasks.md#task-4
+		 */
+		async saveCreationPolicy() {
+			this.savingCreationPolicy = true
+			this.creationPolicySuccess = ''
+			this.creationPolicyError = ''
+			const settingsStore = useSettingsStore()
+			const result = await settingsStore.saveSettings({
+				allow_project_creation: this.creationPolicy,
+			})
+			if (result) {
+				this.creationPolicySuccess = this.t('planix', 'Creation policy saved successfully')
+			} else {
+				this.creationPolicyError = this.t('planix', 'Failed to save creation policy')
+			}
+			this.savingCreationPolicy = false
+		},
+
 		/**
 		 * Trigger SettingsController::load to re-import the planix register.
 		 *


### PR DESCRIPTION
## Summary

- **#263 deleteProject cascade non-transactional**: Error messages now explicitly tell the user some data may remain and to retry. The halt-on-failure strategy is preserved (correct), but the user now has actionable guidance.
- **#265 allow_project_creation never enforced**: `ProjectList.vue` now reads the setting from the settings store; when set to `'admins'`, the New project button, creation dialog mount, and empty-state CTA are all hidden from non-admin users. Added a UI control in `Settings.vue` so admins can configure the policy.
- **#266 default_columns malformed JSON accepted without validation**: `SettingsService.setAdminSettings` now calls `validateDefaultColumns()` before persisting; malformed or invalid shapes are rejected with a logger warning.
- **#267 deep links hash vs history router**: `DeepLinkRegistrationListener` URL templates switched from hash-mode (`#/path`) to history-mode (`/apps/planix/path`) matching the Vue Router configuration. All five hardcoded `'planix'` literals replaced with `Application::APP_ID` (closes #273 overlap).

## Test plan

- [ ] Set allow_project_creation to 'admins' — verify non-admin users see no New project button
- [ ] As admin, set allow_project_creation to 'all' — verify button reappears for all users
- [ ] Submit malformed JSON as default_columns in admin settings — verify it is rejected (old value retained)
- [ ] Verify deep links from unified search navigate to the correct history-mode URL