### PR TITLE
fix(security): schema RBAC — project update owner-only + cross-project create guards

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -34,7 +34,7 @@ Vrij en open source onder de EUPL-1.2-licentie.
 
 **Ondersteuning:** Voor ondersteuning, neem contact op via support@conduction.nl.
     ]]></description>
-    <version>0.2.3</version>
+    <version>0.2.4</version>
     <licence>agpl</licence>
     <author mail="info@conduction.nl" homepage="https://www.conduction.nl/">Conduction</author>
     <namespace>Planix</namespace>

--- a/lib/Settings/planix_register.json
+++ b/lib/Settings/planix_register.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Planix Register",
     "description": "Register containing all schemas for the Planix application.",
-    "version": "0.2.3"
+    "version": "0.2.4"
   },
   "x-openregister": {
     "type": "application",
@@ -18,7 +18,7 @@
         "title": "Planix",
         "description": "Planix application data register — tasks, projects, columns, time entries, and labels.",
         "slug": "planix",
-        "version": "0.2.3",
+        "version": "0.2.4",
         "schemas": ["task", "project", "column", "timeEntry", "label"],
         "tablePrefix": "planix",
         "folder": "planix",
@@ -30,7 +30,7 @@
       "task": {
         "slug": "task",
         "icon": "CheckboxMarkedOutline",
-        "version": "0.1.1",
+        "version": "0.1.2",
         "title": "Task",
         "description": "A discrete unit of work. Maps to iCalendar VTODO (RFC 5545) and schema:PlanAction.",
         "type": "object",
@@ -43,7 +43,13 @@
             },
             { "group": "admin" }
           ],
-          "create": ["authenticated"],
+          "create": [
+            {
+              "group": "authenticated",
+              "match": { "project": { "$in": { "$lookup": { "schema": "project", "field": "id", "where": { "members": { "$contains": "$userId" } } } } } }
+            },
+            { "group": "admin" }
+          ],
           "update": [
             {
               "group": "authenticated",
@@ -158,7 +164,7 @@
       "project": {
         "slug": "project",
         "icon": "FolderOutline",
-        "version": "0.1.1",
+        "version": "0.1.2",
         "title": "Project",
         "description": "A container grouping related tasks and kanban columns. Maps to schema:CreativeWork.",
         "type": "object",
@@ -175,7 +181,7 @@
           "update": [
             {
               "group": "authenticated",
-              "match": { "members": { "$contains": "$userId" } }
+              "match": { "owner": "$userId" }
             },
             { "group": "admin" }
           ],
@@ -247,7 +253,7 @@
       "column": {
         "slug": "column",
         "icon": "ViewColumnOutline",
-        "version": "0.1.1",
+        "version": "0.1.2",
         "title": "Column",
         "description": "A kanban column belonging to a project. Maps to schema:DefinedTerm.",
         "type": "object",
@@ -260,7 +266,13 @@
             },
             { "group": "admin" }
           ],
-          "create": ["authenticated"],
+          "create": [
+            {
+              "group": "authenticated",
+              "match": { "project": { "$in": { "$lookup": { "schema": "project", "field": "id", "where": { "members": { "$contains": "$userId" } } } } } }
+            },
+            { "group": "admin" }
+          ],
           "update": [
             {
               "group": "authenticated",
@@ -312,7 +324,7 @@
       "timeEntry": {
         "slug": "timeEntry",
         "icon": "TimerOutline",
-        "version": "0.1.1",
+        "version": "0.1.2",
         "title": "Time Entry",
         "description": "Time logged by a user against a task. Maps to schema:QuantitativeValue.",
         "type": "object",
@@ -329,7 +341,13 @@
             },
             { "group": "admin" }
           ],
-          "create": ["authenticated"],
+          "create": [
+            {
+              "group": "authenticated",
+              "match": { "user": "$userId" }
+            },
+            { "group": "admin" }
+          ],
           "update": [
             {
               "group": "authenticated",


### PR DESCRIPTION
## Summary

- **C1** `planix_register.json` — `project.update` now requires `owner: $userId` match. Previously any project member could update `owner`/`members` fields, allowing non-owners to evict the owner. Now only the owner (or admin) may update the project.
- **H1** `planix_register.json` — `task.create` and `column.create` now require the caller to be a member of the target project (parent-project lookup predicate), closing cross-project injection. `timeEntry.create` adds `user: $userId` match to prevent impersonation — users may only log time as themselves.
- Schema versions bumped 0.1.1 → 0.1.2 for `task`, `column`, `timeEntry`, `project`; register/info.xml bumped 0.2.3 → 0.2.4.

## Test plan

- [ ] JSON schema valid: `python3 -c "import json; json.load(open('lib/Settings/planix_register.json'))"` — passes
- [ ] Project owner can still update project details
- [ ] Non-owner project member receives 403 on update
- [ ] Task create from non-member project returns 403
- [ ] TimeEntry create with different user UID returns 403